### PR TITLE
feat(extension): add Cmd+F / Ctrl+F keybinding for session filter

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -116,6 +116,14 @@
         "category": "Claude Sessions"
       }
     ],
+    "keybindings": [
+      {
+        "command": "claudeSessions.filterSessions",
+        "key": "ctrl+f",
+        "mac": "cmd+f",
+        "when": "focusedView == claudeSessions"
+      }
+    ],
     "menus": {
       "view/title": [
         {


### PR DESCRIPTION
## Summary

- Add `Cmd+F` (Mac) / `Ctrl+F` (Windows/Linux) keyboard shortcut for the session filter
- Keybinding triggers the existing `claudeSessions.filterSessions` command when the sessions panel is focused
- No changes to extension logic — `package.json` contribution only

## Problem

Currently, opening the session filter requires clicking the 🔍 title-bar icon (two-step: click → modal). There's no keyboard shortcut, making it slow for keyboard-focused users.

## Solution

Added a keybinding in `package.json`:

```json
"keybindings": [
  {
    "command": "claudeSessions.filterSessions",
    "key": "ctrl+f",
    "mac": "cmd+f",
    "when": "focusedView == claudeSessions"
  }
]
```

Pressing `Cmd+F` (Mac) / `Ctrl+F` (Windows/Linux) while the sessions panel is focused now immediately opens the filter input — reducing the interaction from click + type + enter → `Cmd+F` + type + enter.

## Files Changed

- `packages/vscode-extension/package.json` — add `contributes.keybindings` section

## Notes

- This is a partial improvement to #21. The full "always visible persistent filter input" goal remains a longer-term item.
- Risk is very low — no logic change, only a keybinding declaration.

Partially addresses #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut (Ctrl+F on Windows/Linux, Cmd+F on Mac) to filter sessions in the VS Code extension's sessions view for faster navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->