### PR TITLE
fix(hooks): skip tests on branch deletion push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,10 +8,10 @@ current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 # Read stdin to check what's being pushed (branch or tag)
 while read local_ref local_sha remote_ref remote_sha; do
-  # Skip tag deletion (e.g. git push origin :refs/tags/v1.0.0)
+  # Skip deletions (e.g. git push origin --delete branch, git push origin :refs/tags/v1.0.0)
   zero="0000000000000000000000000000000000000000"
-  if [ "$local_sha" = "$zero" ] && echo "$remote_ref" | grep -q "^refs/tags/"; then
-    echo "🗑️  Tag deletion: $remote_ref — skipping tests."
+  if [ "$local_sha" = "$zero" ]; then
+    echo "🗑️  Deletion: $remote_ref — skipping tests."
     continue
   fi
 


### PR DESCRIPTION
Skip pre-push hook tests when pushing a branch deletion. Branch deletion pushes have no code changes, so running tests is unnecessary. Detects deletion by checking if the local ref is the zero SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-push validation to handle all types of deletions uniformly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->