### PR TITLE
refactor(core): extract fileExists helper from repeated access/catch pattern

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export {
   sessionHasSubItems,
   getSessionTooltip,
   canMoveSession,
+  fileExists,
 } from './utils.js'
 
 // Tree view constants and utilities

--- a/packages/core/src/session/crud.ts
+++ b/packages/core/src/session/crud.ts
@@ -8,6 +8,7 @@ import * as crypto from 'node:crypto'
 import { getSessionsDir } from '../paths.js'
 import {
   extractTitle,
+  fileExists,
   isContinuationSummary,
   cleanupSplitFirstMessage,
   parseJsonlLines,
@@ -305,24 +306,14 @@ export const moveSession = (
     const targetFile = path.join(targetPath, `${sessionId}.jsonl`)
 
     // Check source file exists
-    const sourceExists = yield* Effect.tryPromise(() =>
-      fs
-        .access(sourceFile)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const sourceExists = yield* Effect.tryPromise(() => fileExists(sourceFile))
 
     if (!sourceExists) {
       return { success: false, error: 'Source session not found' }
     }
 
     // Check target file does not exist
-    const targetExists = yield* Effect.tryPromise(() =>
-      fs
-        .access(targetFile)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const targetExists = yield* Effect.tryPromise(() => fileExists(targetFile))
 
     if (targetExists) {
       return { success: false, error: 'Session already exists in target project' }
@@ -342,12 +333,7 @@ export const moveSession = (
       const sourceAgentFile = path.join(sourcePath, `${agentId}.jsonl`)
       const targetAgentFile = path.join(targetPath, `${agentId}.jsonl`)
 
-      const agentExists = yield* Effect.tryPromise(() =>
-        fs
-          .access(sourceAgentFile)
-          .then(() => true)
-          .catch(() => false)
-      )
+      const agentExists = yield* Effect.tryPromise(() => fileExists(sourceAgentFile))
 
       if (agentExists) {
         yield* Effect.tryPromise(() => fs.rename(sourceAgentFile, targetAgentFile))

--- a/packages/core/src/session/projects.ts
+++ b/packages/core/src/session/projects.ts
@@ -6,17 +6,13 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { getSessionsDir, folderNameToPath } from '../paths.js'
 import type { Project } from '../types.js'
+import { fileExists } from '../utils.js'
 
 // List all project directories
 export const listProjects = Effect.gen(function* () {
   const sessionsDir = getSessionsDir()
 
-  const exists = yield* Effect.tryPromise(() =>
-    fs
-      .access(sessionsDir)
-      .then(() => true)
-      .catch(() => false)
-  )
+  const exists = yield* Effect.tryPromise(() => fileExists(sessionsDir))
 
   if (!exists) {
     return [] as Project[]

--- a/packages/core/src/session/tree.ts
+++ b/packages/core/src/session/tree.ts
@@ -12,6 +12,7 @@ import {
   getSummarySortTimestamp,
   isErrorSessionTitle,
   parseJsonlLines,
+  fileExists,
   tryParseJsonLine,
 } from '../utils.js'
 import { findLinkedAgents } from '../agents.js'
@@ -471,12 +472,7 @@ export const loadProjectTreeData = (projectName: string, sortOptions?: SessionSo
     const projectPath = path.join(getSessionsDir(), projectName)
 
     // Check project exists (fast: single stat instead of listing ALL projects)
-    const exists = yield* Effect.tryPromise(() =>
-      fs
-        .access(projectPath)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const exists = yield* Effect.tryPromise(() => fileExists(projectPath))
     if (!exists) return null
 
     // Resolve display name for this single project (avoids processing all projects)

--- a/packages/core/src/todos.ts
+++ b/packages/core/src/todos.ts
@@ -6,6 +6,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { getSessionsDir, getTodosDir } from './paths.js'
 import type { TodoItem, SessionTodos } from './types.js'
+import { fileExists } from './utils.js'
 
 // Find linked todo files for a session and its agents
 // Scans todos directory for files matching session pattern
@@ -14,12 +15,7 @@ export const findLinkedTodos = (sessionId: string, agentIds: string[] = []) =>
     const todosDir = getTodosDir()
 
     // Check if todos directory exists
-    const exists = yield* Effect.tryPromise(() =>
-      fs
-        .access(todosDir)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const exists = yield* Effect.tryPromise(() => fileExists(todosDir))
 
     if (!exists) {
       return {
@@ -34,12 +30,7 @@ export const findLinkedTodos = (sessionId: string, agentIds: string[] = []) =>
     const sessionTodoPath = path.join(todosDir, `${sessionId}.json`)
     let sessionTodos: TodoItem[] = []
 
-    const sessionTodoExists = yield* Effect.tryPromise(() =>
-      fs
-        .access(sessionTodoPath)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const sessionTodoExists = yield* Effect.tryPromise(() => fileExists(sessionTodoPath))
 
     if (sessionTodoExists) {
       const content = yield* Effect.tryPromise(() => fs.readFile(sessionTodoPath, 'utf-8'))
@@ -71,12 +62,7 @@ export const findLinkedTodos = (sessionId: string, agentIds: string[] = []) =>
       const shortAgentId = agentId.replace('agent-', '')
       const agentTodoPath = path.join(todosDir, `${sessionId}-agent-${shortAgentId}.json`)
 
-      const agentTodoExists = yield* Effect.tryPromise(() =>
-        fs
-          .access(agentTodoPath)
-          .then(() => true)
-          .catch(() => false)
-      )
+      const agentTodoExists = yield* Effect.tryPromise(() => fileExists(agentTodoPath))
 
       if (agentTodoExists) {
         const content = yield* Effect.tryPromise(() => fs.readFile(agentTodoPath, 'utf-8'))
@@ -108,23 +94,13 @@ export const sessionHasTodos = (sessionId: string, agentIds: string[] = []) =>
     const todosDir = getTodosDir()
 
     // Check if todos directory exists
-    const exists = yield* Effect.tryPromise(() =>
-      fs
-        .access(todosDir)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const exists = yield* Effect.tryPromise(() => fileExists(todosDir))
 
     if (!exists) return false
 
     // Check session's own todo file
     const sessionTodoPath = path.join(todosDir, `${sessionId}.json`)
-    const sessionTodoExists = yield* Effect.tryPromise(() =>
-      fs
-        .access(sessionTodoPath)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const sessionTodoExists = yield* Effect.tryPromise(() => fileExists(sessionTodoPath))
 
     if (sessionTodoExists) {
       const content = yield* Effect.tryPromise(() => fs.readFile(sessionTodoPath, 'utf-8'))
@@ -154,12 +130,7 @@ export const sessionHasTodos = (sessionId: string, agentIds: string[] = []) =>
       const shortAgentId = agentId.replace('agent-', '')
       const agentTodoPath = path.join(todosDir, `${sessionId}-agent-${shortAgentId}.json`)
 
-      const agentTodoExists = yield* Effect.tryPromise(() =>
-        fs
-          .access(agentTodoPath)
-          .then(() => true)
-          .catch(() => false)
-      )
+      const agentTodoExists = yield* Effect.tryPromise(() => fileExists(agentTodoPath))
 
       if (agentTodoExists) {
         const content = yield* Effect.tryPromise(() => fs.readFile(agentTodoPath, 'utf-8'))
@@ -181,12 +152,7 @@ export const deleteLinkedTodos = (sessionId: string, agentIds: string[]) =>
     const todosDir = getTodosDir()
 
     // Check if todos directory exists
-    const exists = yield* Effect.tryPromise(() =>
-      fs
-        .access(todosDir)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const exists = yield* Effect.tryPromise(() => fileExists(todosDir))
 
     if (!exists) return { deletedCount: 0 }
 
@@ -198,12 +164,7 @@ export const deleteLinkedTodos = (sessionId: string, agentIds: string[]) =>
 
     // Delete session's own todo file
     const sessionTodoPath = path.join(todosDir, `${sessionId}.json`)
-    const sessionTodoExists = yield* Effect.tryPromise(() =>
-      fs
-        .access(sessionTodoPath)
-        .then(() => true)
-        .catch(() => false)
-    )
+    const sessionTodoExists = yield* Effect.tryPromise(() => fileExists(sessionTodoPath))
 
     if (sessionTodoExists) {
       const backupPath = path.join(backupDir, `${sessionId}.json`)
@@ -216,12 +177,7 @@ export const deleteLinkedTodos = (sessionId: string, agentIds: string[]) =>
       const shortAgentId = agentId.replace('agent-', '')
       const agentTodoPath = path.join(todosDir, `${sessionId}-agent-${shortAgentId}.json`)
 
-      const agentTodoExists = yield* Effect.tryPromise(() =>
-        fs
-          .access(agentTodoPath)
-          .then(() => true)
-          .catch(() => false)
-      )
+      const agentTodoExists = yield* Effect.tryPromise(() => fileExists(agentTodoPath))
 
       if (agentTodoExists) {
         const backupPath = path.join(backupDir, `${sessionId}-agent-${shortAgentId}.json`)
@@ -241,18 +197,8 @@ export const findOrphanTodos = () =>
 
     // Check if directories exist
     const [todosExists, sessionsExists] = yield* Effect.all([
-      Effect.tryPromise(() =>
-        fs
-          .access(todosDir)
-          .then(() => true)
-          .catch(() => false)
-      ),
-      Effect.tryPromise(() =>
-        fs
-          .access(sessionsDir)
-          .then(() => true)
-          .catch(() => false)
-      ),
+      Effect.tryPromise(() => fileExists(todosDir)),
+      Effect.tryPromise(() => fileExists(sessionsDir)),
     ])
 
     if (!todosExists || !sessionsExists) return []

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -3,6 +3,7 @@ import {
   cleanupSplitFirstMessage,
   extractTextContent,
   extractTitle,
+  fileExists,
   getDisplayTitle,
   maskHomePath,
   parseJsonlLines,
@@ -367,5 +368,38 @@ describe('readJsonlFile', () => {
 
     // Effect.tryPromise wraps the error, so we check that it rejects
     await expect(Effect.runPromise(readJsonlFile('/nonexistent.jsonl'))).rejects.toThrow()
+  })
+})
+
+describe('fileExists', () => {
+  const mockedFs = vi.mocked(fs)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return true when file is accessible', async () => {
+    mockedFs.access.mockResolvedValue(undefined)
+
+    const result = await fileExists('/tmp/existing-file.txt')
+
+    expect(result).toBe(true)
+    expect(mockedFs.access).toHaveBeenCalledWith('/tmp/existing-file.txt')
+  })
+
+  it('should return false when file does not exist', async () => {
+    mockedFs.access.mockRejectedValue(new Error('ENOENT: no such file or directory'))
+
+    const result = await fileExists('/tmp/nonexistent-file.txt')
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false when permission is denied', async () => {
+    mockedFs.access.mockRejectedValue(new Error('EACCES: permission denied'))
+
+    const result = await fileExists('/tmp/restricted-file.txt')
+
+    expect(result).toBe(false)
   })
 })

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -477,3 +477,10 @@ export const getSessionTooltip = (session: {
 export const canMoveSession = (sourceProject: string, targetProject: string): boolean => {
   return sourceProject !== targetProject
 }
+
+/** Check if a file or directory exists at the given path */
+export const fileExists = (filePath: string): Promise<boolean> =>
+  fs
+    .access(filePath)
+    .then(() => true)
+    .catch(() => false)

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -478,7 +478,7 @@ export const canMoveSession = (sourceProject: string, targetProject: string): bo
   return sourceProject !== targetProject
 }
 
-/** Check if a file or directory exists at the given path */
+/** Check if a file or directory is accessible at the given path (returns false for both missing and permission-denied paths) */
 export const fileExists = (filePath: string): Promise<boolean> =>
   fs
     .access(filePath)


### PR DESCRIPTION
## Summary
- Extract repeated `fsp.access(path).then(() => true).catch(() => false)` pattern into a reusable `fileExists` utility
- Reduces code duplication across 5 source files (15+ occurrences to single helper)
- Net reduction of ~68 lines with no behavior change

## Changes
- Add `fileExists` to `packages/core/src/utils.ts`
- Re-export from `packages/core/src/index.ts`
- Replace all occurrences in: `todos.ts`, `session/crud.ts`, `session/tree.ts`, `session/projects.ts`

## Test plan
- [x] `pnpm --filter core build` passes
- [x] `pnpm --filter core test` - 231 tests pass
- [x] `tsc --noEmit` - no type errors
- [x] Pre-push hook: typecheck + all workspace tests pass (core: 231, mcp: 26, vscode: 15, web: 63)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability by consolidating file existence checks across the codebase into a shared utility function, reducing code duplication and enhancing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->