### PR TITLE
refactor(core): replace silent catch blocks with structured logging

### DIFF
--- a/packages/core/src/__tests__/analysis.test.ts
+++ b/packages/core/src/__tests__/analysis.test.ts
@@ -13,7 +13,7 @@ vi.mock('../paths.js', async () => {
 })
 
 import { getSessionsDir } from '../paths.js'
-import { compressSession, readSession } from '../session.js'
+import { analyzeSession, compressSession, readSession, summarizeSession } from '../session.js'
 
 describe('compressSession', () => {
   let tempDir: string
@@ -82,5 +82,548 @@ describe('compressSession', () => {
       type: 'assistant',
       parentUuid: 'p2',
     })
+  })
+
+  it('should remove intermediate snapshots with first_last strategy', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'file-history-snapshot',
+        uuid: 'snap-1',
+        parentUuid: null,
+        snapshot: { trackedFileBackups: { '/a': {} } },
+      },
+      {
+        type: 'user',
+        uuid: 'u1',
+        parentUuid: 'snap-1',
+        message: { role: 'user', content: 'Work' },
+      },
+      {
+        type: 'file-history-snapshot',
+        uuid: 'snap-2',
+        parentUuid: 'u1',
+        snapshot: { trackedFileBackups: { '/b': {} } },
+      },
+      {
+        type: 'file-history-snapshot',
+        uuid: 'snap-3',
+        parentUuid: 'snap-2',
+        snapshot: { trackedFileBackups: { '/c': {} } },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(
+      compressSession(projectName, sessionId, { keepSnapshots: 'first_last' })
+    )
+
+    expect(result.removedSnapshots).toBe(1)
+    const compressed = await Effect.runPromise(readSession(projectName, sessionId))
+    const snapshots = compressed.filter((m) => m.type === 'file-history-snapshot')
+    expect(snapshots).toHaveLength(2)
+  })
+
+  it('should remove all snapshots with none strategy', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      { type: 'file-history-snapshot', uuid: 'snap-1', parentUuid: null, snapshot: {} },
+      {
+        type: 'user',
+        uuid: 'u1',
+        parentUuid: 'snap-1',
+        message: { role: 'user', content: 'Hello' },
+      },
+      { type: 'file-history-snapshot', uuid: 'snap-2', parentUuid: 'u1', snapshot: {} },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(
+      compressSession(projectName, sessionId, { keepSnapshots: 'none' })
+    )
+
+    expect(result.removedSnapshots).toBe(2)
+  })
+
+  it('should keep only the last custom-title', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      { type: 'custom-title', uuid: 'ct1', parentUuid: null, title: 'Old title' },
+      { type: 'user', uuid: 'u1', parentUuid: 'ct1', message: { role: 'user', content: 'Work' } },
+      { type: 'custom-title', uuid: 'ct2', parentUuid: 'u1', title: 'New title' },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(compressSession(projectName, sessionId))
+
+    expect(result.removedCustomTitles).toBe(1)
+    const compressed = await Effect.runPromise(readSession(projectName, sessionId))
+    const titles = compressed.filter((m) => m.type === 'custom-title')
+    expect(titles).toHaveLength(1)
+  })
+
+  it('should truncate long tool outputs', async () => {
+    const sessionId = 'test-session'
+    const longOutput = 'x'.repeat(10000)
+    const messages = [
+      {
+        type: 'user',
+        uuid: 'u1',
+        parentUuid: null,
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: longOutput },
+          { type: 'tool_result', tool_use_id: 't2', content: 'short' },
+        ],
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(
+      compressSession(projectName, sessionId, { maxToolOutputLength: 100 })
+    )
+
+    expect(result.truncatedOutputs).toBe(1)
+    const content = await fs.readFile(path.join(projectDir, `${sessionId}.jsonl`), 'utf-8')
+    const line = JSON.parse(content.trim())
+    expect(line.content[0].content).toContain('[truncated]')
+    expect(line.content[1].content).toBe('short')
+  })
+
+  it('should reduce file size after compression', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      { type: 'user', uuid: 'u1', parentUuid: null, message: { role: 'user', content: 'Hello' } },
+      {
+        type: 'progress',
+        uuid: 'p1',
+        parentUuid: 'u1',
+        data: { hookEvent: 'ToolUse', payload: 'x'.repeat(500) },
+      },
+      {
+        type: 'progress',
+        uuid: 'p2',
+        parentUuid: 'p1',
+        data: { hookEvent: 'ToolResult', payload: 'y'.repeat(500) },
+      },
+      {
+        type: 'file-history-snapshot',
+        uuid: 'snap-1',
+        parentUuid: 'p2',
+        snapshot: { trackedFileBackups: { '/a': { content: 'z'.repeat(500) } } },
+      },
+      {
+        type: 'file-history-snapshot',
+        uuid: 'snap-2',
+        parentUuid: 'snap-1',
+        snapshot: { trackedFileBackups: { '/b': { content: 'w'.repeat(500) } } },
+      },
+      {
+        type: 'file-history-snapshot',
+        uuid: 'snap-3',
+        parentUuid: 'snap-2',
+        snapshot: { trackedFileBackups: { '/c': { content: 'v'.repeat(500) } } },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        parentUuid: 'snap-3',
+        message: { role: 'assistant', content: 'Done' },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(compressSession(projectName, sessionId))
+
+    expect(result.compressedSize).toBeLessThan(result.originalSize)
+  })
+})
+
+describe('analyzeSession', () => {
+  let tempDir: string
+  let projectDir: string
+  const projectName = '-Users-test-analysis'
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-session-analyze-'))
+    projectDir = path.join(tempDir, projectName)
+    await fs.mkdir(projectDir, { recursive: true })
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('should count message types correctly', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'user',
+        uuid: 'u1',
+        timestamp: '2025-01-01T00:00:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        timestamp: '2025-01-01T00:01:00Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Hi' }] },
+      },
+      {
+        type: 'user',
+        uuid: 'u2',
+        timestamp: '2025-01-01T00:02:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Help' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a2',
+        timestamp: '2025-01-01T00:03:00Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Sure' }] },
+      },
+      { type: 'summary', uuid: 's1', summary: 'Session about greetings' },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(analyzeSession(projectName, sessionId))
+
+    expect(result.stats.totalMessages).toBe(5)
+    expect(result.stats.userMessages).toBe(2)
+    expect(result.stats.assistantMessages).toBe(2)
+    expect(result.stats.summaryCount).toBe(1)
+  })
+
+  it('should calculate session duration in minutes', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'user',
+        uuid: 'u1',
+        timestamp: '2025-01-01T00:00:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Start' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        timestamp: '2025-01-01T01:30:00Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'End' }] },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(analyzeSession(projectName, sessionId))
+
+    expect(result.durationMinutes).toBe(90)
+  })
+
+  it('should track tool usage from assistant messages', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        timestamp: '2025-01-01T00:00:00Z',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 't1',
+              name: 'Read',
+              input: { file_path: '/project/src/index.ts' },
+            },
+            {
+              type: 'tool_use',
+              id: 't2',
+              name: 'Edit',
+              input: { file_path: '/project/src/index.ts' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a2',
+        timestamp: '2025-01-01T00:01:00Z',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 't3',
+              name: 'Read',
+              input: { file_path: '/project/src/utils.ts' },
+            },
+          ],
+        },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(analyzeSession(projectName, sessionId))
+
+    const readTool = result.toolUsage.find((t) => t.name === 'Read')
+    const editTool = result.toolUsage.find((t) => t.name === 'Edit')
+    expect(readTool?.count).toBe(2)
+    expect(editTool?.count).toBe(1)
+  })
+
+  it('should track files changed via Write and Edit tools', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        timestamp: '2025-01-01T00:00:00Z',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 't1',
+              name: 'Write',
+              input: { file_path: '/project/new-file.ts' },
+            },
+            {
+              type: 'tool_use',
+              id: 't2',
+              name: 'Edit',
+              input: { file_path: '/project/existing.ts' },
+            },
+          ],
+        },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(analyzeSession(projectName, sessionId))
+
+    expect(result.filesChanged).toContain('/project/new-file.ts')
+    expect(result.filesChanged).toContain('/project/existing.ts')
+  })
+
+  it('should detect high error rate pattern', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        timestamp: '2025-01-01T00:00:00Z',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 't1', name: 'Bash', input: {} },
+            { type: 'tool_use', id: 't2', name: 'Bash', input: {} },
+            { type: 'tool_use', id: 't3', name: 'Bash', input: {} },
+            { type: 'tool_use', id: 't4', name: 'Bash', input: {} },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'u1',
+        timestamp: '2025-01-01T00:00:01Z',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', is_error: true, content: 'Error' },
+          { type: 'tool_result', tool_use_id: 't2', is_error: true, content: 'Error' },
+          { type: 'tool_result', tool_use_id: 't3', content: 'OK' },
+          { type: 'tool_result', tool_use_id: 't4', is_error: true, content: 'Error' },
+        ],
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(analyzeSession(projectName, sessionId))
+
+    const highErrorPattern = result.patterns.find((p) => p.type === 'high_error_rate')
+    expect(highErrorPattern).toBeDefined()
+    expect(highErrorPattern?.count).toBe(3)
+  })
+
+  it('should detect many snapshots pattern', async () => {
+    const sessionId = 'test-session'
+    const snapshots = Array.from({ length: 12 }, (_, i) => ({
+      type: 'file-history-snapshot',
+      messageId: `msg-${i}`,
+      timestamp: `2025-01-01T00:${String(i).padStart(2, '0')}:00Z`,
+      snapshot: { trackedFileBackups: {} },
+    }))
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      snapshots.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(analyzeSession(projectName, sessionId))
+
+    expect(result.stats.snapshotCount).toBe(12)
+    const snapshotPattern = result.patterns.find((p) => p.type === 'many_snapshots')
+    expect(snapshotPattern).toBeDefined()
+  })
+})
+
+describe('summarizeSession', () => {
+  let tempDir: string
+  let projectDir: string
+  const projectName = '-Users-test-analysis'
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-session-summarize-'))
+    projectDir = path.join(tempDir, projectName)
+    await fs.mkdir(projectDir, { recursive: true })
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('should extract user and assistant conversation lines', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'user',
+        uuid: 'u1',
+        timestamp: '2025-01-01T09:00:00Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'What is TypeScript?' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        timestamp: '2025-01-01T09:01:00Z',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'TypeScript is a typed superset of JavaScript.' }],
+        },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(summarizeSession(projectName, sessionId))
+
+    expect(result.lines).toHaveLength(2)
+    expect(result.lines[0].role).toBe('user')
+    expect(result.lines[0].content).toContain('TypeScript')
+    expect(result.lines[1].role).toBe('assistant')
+  })
+
+  it('should respect limit option', async () => {
+    const sessionId = 'test-session'
+    const messages = Array.from({ length: 10 }, (_, i) => ({
+      type: i % 2 === 0 ? 'user' : 'assistant',
+      uuid: `msg-${i}`,
+      timestamp: `2025-01-01T00:${String(i).padStart(2, '0')}:00Z`,
+      message: {
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: [{ type: 'text', text: `Message ${i}` }],
+      },
+    }))
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(summarizeSession(projectName, sessionId, { limit: 3 }))
+
+    expect(result.lines).toHaveLength(3)
+  })
+
+  it('should truncate long messages', async () => {
+    const sessionId = 'test-session'
+    const longText = 'A'.repeat(500)
+    const messages = [
+      {
+        type: 'user',
+        uuid: 'u1',
+        message: { role: 'user', content: [{ type: 'text', text: longText }] },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(
+      summarizeSession(projectName, sessionId, { maxLength: 50 })
+    )
+
+    expect(result.lines[0].content.length).toBeLessThanOrEqual(53) // 50 + "..."
+  })
+
+  it('should skip non-conversation message types', async () => {
+    const sessionId = 'test-session'
+    const messages = [
+      {
+        type: 'user',
+        uuid: 'u1',
+        message: { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      },
+      { type: 'summary', uuid: 's1', summary: 'A summary' },
+      { type: 'file-history-snapshot', uuid: 'snap1', snapshot: {} },
+      {
+        type: 'assistant',
+        uuid: 'a1',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Reply' }] },
+      },
+    ]
+
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+    )
+
+    const result = await Effect.runPromise(summarizeSession(projectName, sessionId))
+
+    expect(result.lines).toHaveLength(2)
+    expect(result.lines[0].role).toBe('user')
+    expect(result.lines[1].role).toBe('assistant')
   })
 })

--- a/packages/core/src/__tests__/analysis.test.ts
+++ b/packages/core/src/__tests__/analysis.test.ts
@@ -126,6 +126,7 @@ describe('compressSession', () => {
     const compressed = await Effect.runPromise(readSession(projectName, sessionId))
     const snapshots = compressed.filter((m) => m.type === 'file-history-snapshot')
     expect(snapshots).toHaveLength(2)
+    expect(snapshots.map((s) => s.uuid)).toEqual(['snap-1', 'snap-3'])
   })
 
   it('should remove all snapshots with none strategy', async () => {
@@ -151,6 +152,8 @@ describe('compressSession', () => {
     )
 
     expect(result.removedSnapshots).toBe(2)
+    const compressed = await Effect.runPromise(readSession(projectName, sessionId))
+    expect(compressed.some((m) => m.type === 'file-history-snapshot')).toBe(false)
   })
 
   it('should keep only the last custom-title', async () => {
@@ -172,6 +175,7 @@ describe('compressSession', () => {
     const compressed = await Effect.runPromise(readSession(projectName, sessionId))
     const titles = compressed.filter((m) => m.type === 'custom-title')
     expect(titles).toHaveLength(1)
+    expect(titles[0]).toMatchObject({ uuid: 'ct2', title: 'New title' })
   })
 
   it('should truncate long tool outputs', async () => {

--- a/packages/core/src/__tests__/todos.test.ts
+++ b/packages/core/src/__tests__/todos.test.ts
@@ -1,0 +1,466 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { Effect } from 'effect'
+
+vi.mock('../paths.js', async () => {
+  const actual = await vi.importActual('../paths.js')
+  return {
+    ...actual,
+    getTodosDir: vi.fn(),
+    getSessionsDir: vi.fn(),
+  }
+})
+
+import {
+  findLinkedTodos,
+  sessionHasTodos,
+  deleteLinkedTodos,
+  findOrphanTodos,
+  deleteOrphanTodos,
+} from '../todos.js'
+import { getTodosDir, getSessionsDir } from '../paths.js'
+
+describe('todos', () => {
+  let tempDir: string
+  let todosDir: string
+  let sessionsDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-todos-test-'))
+    todosDir = path.join(tempDir, 'todos')
+    sessionsDir = path.join(tempDir, 'projects')
+    await fs.mkdir(todosDir, { recursive: true })
+    await fs.mkdir(sessionsDir, { recursive: true })
+    vi.mocked(getTodosDir).mockReturnValue(todosDir)
+    vi.mocked(getSessionsDir).mockReturnValue(sessionsDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  describe('findLinkedTodos', () => {
+    it('should return empty result when todos directory does not exist', async () => {
+      vi.mocked(getTodosDir).mockReturnValue(path.join(tempDir, 'nonexistent'))
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1'))
+
+      expect(result.sessionId).toBe('session-1')
+      expect(result.sessionTodos).toEqual([])
+      expect(result.agentTodos).toEqual([])
+      expect(result.hasTodos).toBe(false)
+    })
+
+    it('should read session todos from matching JSON file', async () => {
+      const todos = [
+        { content: 'Fix unit tests', status: 'pending' },
+        { content: 'Update docs', status: 'completed' },
+      ]
+      await fs.writeFile(path.join(todosDir, 'session-1.json'), JSON.stringify(todos))
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1'))
+
+      expect(result.sessionTodos).toEqual(todos)
+      expect(result.hasTodos).toBe(true)
+    })
+
+    it('should return empty session todos when file does not exist', async () => {
+      const result = await Effect.runPromise(findLinkedTodos('nonexistent-session'))
+
+      expect(result.sessionTodos).toEqual([])
+      expect(result.hasTodos).toBe(false)
+    })
+
+    it('should handle invalid JSON in session todo file', async () => {
+      await fs.writeFile(path.join(todosDir, 'session-1.json'), 'not-valid-json')
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1'))
+
+      expect(result.sessionTodos).toEqual([])
+      expect(result.hasTodos).toBe(false)
+    })
+
+    it('should discover agent todos from directory scan', async () => {
+      const agentTodos = [{ content: 'Agent task', status: 'in_progress' }]
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-abc123.json'),
+        JSON.stringify(agentTodos)
+      )
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1'))
+
+      expect(result.agentTodos).toHaveLength(1)
+      expect(result.agentTodos[0].agentId).toBe('agent-abc123')
+      expect(result.agentTodos[0].todos).toEqual(agentTodos)
+      expect(result.hasTodos).toBe(true)
+    })
+
+    it('should include agent todos from provided agentIds', async () => {
+      const agentTodos = [{ content: 'Provided agent task', status: 'pending' }]
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-def456.json'),
+        JSON.stringify(agentTodos)
+      )
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1', ['agent-def456']))
+
+      expect(result.agentTodos).toHaveLength(1)
+      expect(result.agentTodos[0].agentId).toBe('agent-def456')
+    })
+
+    it('should deduplicate agent IDs from scan and provided list', async () => {
+      const agentTodos = [{ content: 'Task', status: 'pending' }]
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-abc123.json'),
+        JSON.stringify(agentTodos)
+      )
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1', ['agent-abc123']))
+
+      // Should only appear once despite being in both scan and provided list
+      expect(result.agentTodos).toHaveLength(1)
+    })
+
+    it('should skip agent files with empty todos array', async () => {
+      await fs.writeFile(path.join(todosDir, 'session-1-agent-abc123.json'), JSON.stringify([]))
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1'))
+
+      expect(result.agentTodos).toEqual([])
+      expect(result.hasTodos).toBe(false)
+    })
+
+    it('should handle invalid JSON in agent todo file', async () => {
+      await fs.writeFile(path.join(todosDir, 'session-1-agent-abc123.json'), 'invalid')
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1'))
+
+      expect(result.agentTodos).toEqual([])
+    })
+
+    it('should combine session and agent todos', async () => {
+      const sessionTodos = [{ content: 'Session task', status: 'pending' }]
+      const agentTodos = [{ content: 'Agent task', status: 'completed' }]
+
+      await fs.writeFile(path.join(todosDir, 'session-1.json'), JSON.stringify(sessionTodos))
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-abc123.json'),
+        JSON.stringify(agentTodos)
+      )
+
+      const result = await Effect.runPromise(findLinkedTodos('session-1'))
+
+      expect(result.sessionTodos).toEqual(sessionTodos)
+      expect(result.agentTodos).toHaveLength(1)
+      expect(result.hasTodos).toBe(true)
+    })
+  })
+
+  describe('sessionHasTodos', () => {
+    it('should return false when todos directory does not exist', async () => {
+      vi.mocked(getTodosDir).mockReturnValue(path.join(tempDir, 'nonexistent'))
+
+      const result = await Effect.runPromise(sessionHasTodos('session-1'))
+
+      expect(result).toBe(false)
+    })
+
+    it('should return true when session has todos', async () => {
+      const todos = [{ content: 'Task', status: 'pending' }]
+      await fs.writeFile(path.join(todosDir, 'session-1.json'), JSON.stringify(todos))
+
+      const result = await Effect.runPromise(sessionHasTodos('session-1'))
+
+      expect(result).toBe(true)
+    })
+
+    it('should return false when session todo file is empty array', async () => {
+      await fs.writeFile(path.join(todosDir, 'session-1.json'), JSON.stringify([]))
+
+      const result = await Effect.runPromise(sessionHasTodos('session-1'))
+
+      expect(result).toBe(false)
+    })
+
+    it('should return false when session todo file has invalid JSON', async () => {
+      await fs.writeFile(path.join(todosDir, 'session-1.json'), 'bad-json')
+
+      const result = await Effect.runPromise(sessionHasTodos('session-1'))
+
+      expect(result).toBe(false)
+    })
+
+    it('should return true when agent has todos', async () => {
+      const agentTodos = [{ content: 'Agent task', status: 'pending' }]
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-abc123.json'),
+        JSON.stringify(agentTodos)
+      )
+
+      const result = await Effect.runPromise(sessionHasTodos('session-1'))
+
+      expect(result).toBe(true)
+    })
+
+    it('should return true when provided agentId has todos', async () => {
+      const agentTodos = [{ content: 'Task', status: 'pending' }]
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-def456.json'),
+        JSON.stringify(agentTodos)
+      )
+
+      const result = await Effect.runPromise(sessionHasTodos('session-1', ['agent-def456']))
+
+      expect(result).toBe(true)
+    })
+
+    it('should return false when no todos exist for session', async () => {
+      // Other session's todo file exists but not for session-1
+      await fs.writeFile(
+        path.join(todosDir, 'other-session.json'),
+        JSON.stringify([{ content: 'Task', status: 'pending' }])
+      )
+
+      const result = await Effect.runPromise(sessionHasTodos('session-1'))
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('deleteLinkedTodos', () => {
+    it('should return zero count when todos directory does not exist', async () => {
+      vi.mocked(getTodosDir).mockReturnValue(path.join(tempDir, 'nonexistent'))
+
+      const result = await Effect.runPromise(deleteLinkedTodos('session-1', []))
+
+      expect(result.deletedCount).toBe(0)
+    })
+
+    it('should move session todo file to backup directory', async () => {
+      const todos = [{ content: 'Task', status: 'pending' }]
+      await fs.writeFile(path.join(todosDir, 'session-1.json'), JSON.stringify(todos))
+
+      const result = await Effect.runPromise(deleteLinkedTodos('session-1', []))
+
+      expect(result.deletedCount).toBe(1)
+
+      // Original file should be gone
+      await expect(fs.access(path.join(todosDir, 'session-1.json'))).rejects.toThrow()
+
+      // Backup should exist
+      const backupContent = await fs.readFile(
+        path.join(todosDir, '.bak', 'session-1.json'),
+        'utf-8'
+      )
+      expect(JSON.parse(backupContent)).toEqual(todos)
+    })
+
+    it('should move agent todo files to backup directory', async () => {
+      const agentTodos = [{ content: 'Agent task', status: 'completed' }]
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-abc123.json'),
+        JSON.stringify(agentTodos)
+      )
+
+      const result = await Effect.runPromise(deleteLinkedTodos('session-1', ['agent-abc123']))
+
+      expect(result.deletedCount).toBe(1)
+
+      // Original should be gone
+      await expect(fs.access(path.join(todosDir, 'session-1-agent-abc123.json'))).rejects.toThrow()
+
+      // Backup should exist
+      await expect(
+        fs.access(path.join(todosDir, '.bak', 'session-1-agent-abc123.json'))
+      ).resolves.toBeUndefined()
+    })
+
+    it('should handle session with both session and agent todos', async () => {
+      await fs.writeFile(
+        path.join(todosDir, 'session-1.json'),
+        JSON.stringify([{ content: 'Session task', status: 'pending' }])
+      )
+      await fs.writeFile(
+        path.join(todosDir, 'session-1-agent-abc123.json'),
+        JSON.stringify([{ content: 'Agent task', status: 'pending' }])
+      )
+
+      const result = await Effect.runPromise(deleteLinkedTodos('session-1', ['agent-abc123']))
+
+      expect(result.deletedCount).toBe(2)
+    })
+
+    it('should not count nonexistent files', async () => {
+      const result = await Effect.runPromise(deleteLinkedTodos('session-1', ['agent-nonexistent']))
+
+      expect(result.deletedCount).toBe(0)
+    })
+  })
+
+  describe('findOrphanTodos', () => {
+    it('should return empty when todos directory does not exist', async () => {
+      vi.mocked(getTodosDir).mockReturnValue(path.join(tempDir, 'nonexistent'))
+
+      const result = await Effect.runPromise(findOrphanTodos())
+
+      expect(result).toEqual([])
+    })
+
+    it('should return empty when sessions directory does not exist', async () => {
+      vi.mocked(getSessionsDir).mockReturnValue(path.join(tempDir, 'nonexistent'))
+
+      const result = await Effect.runPromise(findOrphanTodos())
+
+      expect(result).toEqual([])
+    })
+
+    it('should identify orphan todo files', async () => {
+      // Session IDs must be hex to match regex /^([a-f0-9-]+)/
+      const validId = 'aaa111-bbb2-ccc3'
+      const orphanId = 'ddd444-eee5-fff6'
+
+      const projectDir = path.join(sessionsDir, '-test-project')
+      await fs.mkdir(projectDir, { recursive: true })
+      await fs.writeFile(path.join(projectDir, `${validId}.jsonl`), '')
+
+      await fs.writeFile(
+        path.join(todosDir, `${validId}.json`),
+        JSON.stringify([{ content: 'Task', status: 'pending' }])
+      )
+
+      await fs.writeFile(
+        path.join(todosDir, `${orphanId}.json`),
+        JSON.stringify([{ content: 'Orphan task', status: 'pending' }])
+      )
+
+      const result = await Effect.runPromise(findOrphanTodos())
+
+      expect(result).toEqual([`${orphanId}.json`])
+    })
+
+    it('should identify orphan agent todo files', async () => {
+      const validId = 'aaa111-bbb2-ccc3'
+      const orphanId = 'ddd444-eee5-fff6'
+
+      const projectDir = path.join(sessionsDir, '-test-project')
+      await fs.mkdir(projectDir, { recursive: true })
+      await fs.writeFile(path.join(projectDir, `${validId}.jsonl`), '')
+
+      await fs.writeFile(
+        path.join(todosDir, `${orphanId}-agent-abc123.json`),
+        JSON.stringify([{ content: 'Task', status: 'pending' }])
+      )
+
+      const result = await Effect.runPromise(findOrphanTodos())
+
+      expect(result).toEqual([`${orphanId}-agent-abc123.json`])
+    })
+
+    it('should not flag valid session todos as orphans', async () => {
+      const sessionId = 'aaa111-bbb2-ccc3'
+
+      const projectDir = path.join(sessionsDir, '-test-project')
+      await fs.mkdir(projectDir, { recursive: true })
+      await fs.writeFile(path.join(projectDir, `${sessionId}.jsonl`), '')
+
+      await fs.writeFile(
+        path.join(todosDir, `${sessionId}.json`),
+        JSON.stringify([{ content: 'Active task', status: 'in_progress' }])
+      )
+
+      const result = await Effect.runPromise(findOrphanTodos())
+
+      expect(result).toEqual([])
+    })
+
+    it('should skip hidden directories in sessions', async () => {
+      const sessionId = 'aaa111-bbb2-ccc3'
+
+      const hiddenDir = path.join(sessionsDir, '.hidden')
+      await fs.mkdir(hiddenDir, { recursive: true })
+      await fs.writeFile(path.join(hiddenDir, `${sessionId}.jsonl`), '')
+
+      await fs.writeFile(
+        path.join(todosDir, `${sessionId}.json`),
+        JSON.stringify([{ content: 'Task', status: 'pending' }])
+      )
+
+      // Session is only in hidden dir, so todo is orphan
+      const result = await Effect.runPromise(findOrphanTodos())
+
+      expect(result).toEqual([`${sessionId}.json`])
+    })
+
+    it('should ignore non-hex filenames in todos directory', async () => {
+      // Filenames with non-hex chars won't match the regex pattern
+      await fs.writeFile(
+        path.join(todosDir, 'not-hex-name.json'),
+        JSON.stringify([{ content: 'Task', status: 'pending' }])
+      )
+
+      const result = await Effect.runPromise(findOrphanTodos())
+
+      // Non-hex filenames are not matched by regex, so not flagged
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('deleteOrphanTodos', () => {
+    it('should return zero when no orphans exist', async () => {
+      const result = await Effect.runPromise(deleteOrphanTodos())
+
+      expect(result).toEqual({ success: true, deletedCount: 0 })
+    })
+
+    it('should move orphan todos to backup and return count', async () => {
+      // No valid sessions
+      await fs.writeFile(
+        path.join(todosDir, 'aaa111.json'),
+        JSON.stringify([{ content: 'Orphan', status: 'pending' }])
+      )
+
+      const result = await Effect.runPromise(deleteOrphanTodos())
+
+      expect(result.success).toBe(true)
+      expect(result.deletedCount).toBe(1)
+
+      // Original should be gone
+      await expect(fs.access(path.join(todosDir, 'aaa111.json'))).rejects.toThrow()
+
+      // Backup should exist
+      await expect(fs.access(path.join(todosDir, '.bak', 'aaa111.json'))).resolves.toBeUndefined()
+    })
+
+    it('should only delete orphans and preserve valid session todos', async () => {
+      // Create valid session
+      const projectDir = path.join(sessionsDir, '-Users-test-project')
+      await fs.mkdir(projectDir, { recursive: true })
+      await fs.writeFile(path.join(projectDir, 'aaa111.jsonl'), '')
+
+      // Valid todo
+      await fs.writeFile(
+        path.join(todosDir, 'aaa111.json'),
+        JSON.stringify([{ content: 'Valid', status: 'pending' }])
+      )
+
+      // Orphan todo
+      await fs.writeFile(
+        path.join(todosDir, 'bbb222.json'),
+        JSON.stringify([{ content: 'Orphan', status: 'pending' }])
+      )
+
+      const result = await Effect.runPromise(deleteOrphanTodos())
+
+      expect(result.deletedCount).toBe(1)
+
+      // Valid todo should still exist
+      await expect(fs.access(path.join(todosDir, 'aaa111.json'))).resolves.toBeUndefined()
+
+      // Orphan should be moved to backup
+      await expect(fs.access(path.join(todosDir, 'bbb222.json'))).rejects.toThrow()
+    })
+  })
+})

--- a/packages/core/src/agents.ts
+++ b/packages/core/src/agents.ts
@@ -4,8 +4,11 @@
 import { Effect } from 'effect'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
+import { createLogger } from './logger.js'
 import { getSessionsDir } from './paths.js'
 import { tryParseJsonLine } from './utils.js'
+
+const log = createLogger('agents')
 import type { Message } from './types.js'
 
 // Find agent files linked to a session
@@ -28,8 +31,8 @@ export const findLinkedAgents = (projectName: string, sessionId: string) =>
           if (parsed.sessionId === sessionId) {
             linkedAgents.push(agentFile.replace('.jsonl', ''))
           }
-        } catch {
-          // Skip invalid JSON
+        } catch (error) {
+          log.debug(`Skipping invalid JSON in agent file: ${agentFile}`, error)
         }
       }
     }
@@ -79,8 +82,8 @@ const findOrphanAgentsWithPaths = (projectName: string) =>
             lineCount: lines.length,
           }
         }
-      } catch {
-        // Skip invalid files
+      } catch (error) {
+        log.debug(`Skipping invalid agent file: ${path.basename(filePath)}`, error)
       }
       return null
     }

--- a/packages/core/src/session/tree.ts
+++ b/packages/core/src/session/tree.ts
@@ -150,8 +150,8 @@ const loadSessionTreeDataInternal = (
               })
             }
           }
-        } catch {
-          // Skip unreadable files
+        } catch (error) {
+          log.debug(`Skipping unreadable file: ${file}`, error)
         }
       }
     }
@@ -226,8 +226,8 @@ const loadSessionTreeDataInternal = (
           name: agentName,
           messageCount: agentUserAssistant.length,
         })
-      } catch {
-        // Agent file might not exist or be readable
+      } catch (error) {
+        log.debug(`Agent file not readable: ${agentId}`, error)
         agents.push({
           id: agentId,
           messageCount: 0,
@@ -328,8 +328,8 @@ const buildPhase1 = (projectPath: string, allJsonlFiles: string[]) =>
                 })
               }
             }
-          } catch {
-            // Skip unreadable files
+          } catch (error) {
+            log.debug(`Skipping unreadable file: ${file}`, error)
           }
         })
       ),
@@ -497,8 +497,8 @@ export const loadProjectTreeData = (projectName: string, sortOptions?: SessionSo
           try {
             const stat = yield* Effect.tryPromise(() => fs.stat(filePath))
             fileMtimes.set(file.replace('.jsonl', ''), stat.mtimeMs)
-          } catch {
-            // Ignore stat errors
+          } catch (error) {
+            log.debug(`Failed to stat file: ${file}`, error)
           }
         })
       ),


### PR DESCRIPTION
## Summary

- Replace 6 silent catch blocks with debug-level logging using existing `createLogger` utility
- `tree.ts`: 4 catch blocks (unreadable files, agent files, stat errors)
- `agents.ts`: 2 catch blocks (invalid JSON, invalid files) + added `createLogger` import
- No behavior change — pure observability improvement

## Test plan

- [x] Core tests pass (231 tests)
- [x] MCP tests pass (26 tests)
- [x] VSCode extension tests pass (15 tests)
- [x] Web tests pass (63 tests)
- [x] TypeScript typecheck passes
- [ ] Verify debug logs appear when files are unreadable (manual)

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for session analysis and summarization functionality, including message statistics, tool usage tracking, and file operations.
  * Added comprehensive test suite for todo and session file management, covering directory operations and orphan file detection.
  * Extended compression tests for snapshot retention strategies and tool output truncation.

* **Chores**
  * Improved debug logging for file parsing and reading errors across agent and session tree modules for better troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->