### PR TITLE
feat(extension): add Start Claude in Folder command

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -109,6 +109,11 @@
         "icon": "$(terminal)"
       },
       {
+        "command": "claudeSessions.startClaudeInFolder",
+        "title": "Start Claude in Folder",
+        "icon": "$(play-circle)"
+      },
+      {
         "command": "claudeSessions.startClaudeYolo",
         "title": "Start Claude (YOLO)",
         "icon": "$(zap)"
@@ -282,9 +287,14 @@
           "group": "1_open"
         },
         {
+          "command": "claudeSessions.startClaudeInFolder",
+          "when": "view == claudeSessions && viewItem == project",
+          "group": "2_claude"
+        },
+        {
           "command": "claudeSessions.startClaudeYolo",
           "when": "view == claudeSessions && viewItem == project",
-          "group": "1_open"
+          "group": "2_claude"
         }
       ]
     },

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -729,6 +729,69 @@ export function activate(context: vscode.ExtensionContext) {
     ),
 
     vscode.commands.registerCommand(
+      'claudeSessions.startClaudeInFolder',
+      async (item: SessionTreeItem) => {
+        if (!item || (item.type !== 'session' && item.type !== 'project')) return
+
+        const { defaultTerminalMode, cliFlags } = getConfig()
+        const cliCommand = cliFlags ? `claude ${cliFlags}` : 'claude'
+        const cwd = await resolveProjectCwd(item.projectName)
+
+        let mode: 'internal' | 'external'
+        if (defaultTerminalMode === 'internal' || defaultTerminalMode === 'external') {
+          mode = defaultTerminalMode
+        } else {
+          const choice = await vscode.window.showQuickPick(
+            [
+              {
+                label: '$(terminal) Internal Terminal',
+                description: 'Open in VSCode integrated terminal',
+                mode: 'internal' as const,
+              },
+              {
+                label: '$(link-external) External Terminal',
+                description: 'Open in system default terminal',
+                mode: 'external' as const,
+              },
+            ],
+            {
+              placeHolder: 'Where to start Claude?',
+              title: 'Start Claude in Folder',
+            }
+          )
+
+          if (!choice) return
+          mode = choice.mode
+        }
+
+        if (mode === 'internal') {
+          const terminal = vscode.window.createTerminal({
+            name: `Claude: ${shortProjectName(item.projectName)}`,
+            cwd,
+          })
+          terminal.show()
+          terminal.sendText(cliCommand)
+        } else {
+          const args = cliFlags ? cliFlags.split(/\s+/).filter(Boolean) : []
+          const child = spawn('claude', args, {
+            cwd,
+            detached: true,
+            stdio: 'ignore',
+          })
+          child.unref()
+
+          if (child.pid) {
+            vscode.window.showInformationMessage(
+              `Claude started in external terminal (PID: ${child.pid})`
+            )
+          } else {
+            vscode.window.showErrorMessage('Failed to start Claude')
+          }
+        }
+      }
+    ),
+
+    vscode.commands.registerCommand(
       'claudeSessions.startClaudeYolo',
       async (item: SessionTreeItem) => {
         if (!item || (item.type !== 'session' && item.type !== 'project')) return


### PR DESCRIPTION
## Summary

- Adds a **"Start Claude in Folder"** entry to the project right-click context menu
- Honors `cliFlags` and `defaultTerminalMode` settings (unlike the hardcoded YOLO command)
- Placed in a separate `2_claude` menu group with a separator line above, alongside the existing "Start Claude (YOLO)"

## Motivation

The existing "Start Claude (YOLO)" always uses `--dangerously-skip-permissions`. This adds a settings-aware alternative that respects the user's `cliFlags` configuration — launching Claude normally by default, or with custom flags if configured.

## Test plan

- [ ] Right-click a project folder → "Start Claude in Folder" appears below a separator
- [ ] With `defaultTerminalMode: "ask"` → shows internal/external picker
- [ ] With `defaultTerminalMode: "internal"` → opens directly in integrated terminal
- [ ] With `cliFlags` set → flags are appended to the `claude` command
- [ ] With empty `cliFlags` → runs plain `claude`
- [ ] "Start Claude (YOLO)" still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Start Claude in Folder" command to quickly launch Claude in a selected project folder.
  * Support for both internal and external terminal modes with configurable default preference.
  * User can be prompted to select terminal type when default is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->