### PR TITLE
feat(vscode): add startClaudeInFolder + toolbar buttons for project commands

### DIFF
--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -1,33 +1,22 @@
 /**
- * Resume session functionality - Server-side only
+ * Resume/start session functionality - Server-side only
  * This module uses child_process and should NOT be imported in browser environments
  */
 import { spawn } from 'node:child_process'
-import type { ResumeSessionOptions, ResumeSessionResult } from './types.js'
+import type { ResumeSessionOptions, ResumeSessionResult, StartClaudeOptions } from './types.js'
 
 /**
- * Resume a session using claude CLI
- * On macOS: opens Terminal.app with claude --resume command
- * On other platforms: spawns a detached process with appropriate terminal
+ * Start claude CLI in an external terminal window.
+ * OS-specific: Terminal.app (macOS), cmd (Windows), gnome-terminal/konsole/xterm (Linux)
  */
-export const resumeSession = (options: ResumeSessionOptions): ResumeSessionResult => {
-  const { sessionId, cwd, fork = false, args = [] } = options
+export const startClaude = (options: StartClaudeOptions): ResumeSessionResult => {
+  const { command, cwd } = options
+  const workingDir = cwd ?? process.cwd()
 
   try {
-    const claudeArgs = ['--resume', sessionId]
-    if (fork) {
-      claudeArgs.push('--fork-session')
-    }
-    claudeArgs.push(...args)
-
-    const claudeCommand = `claude ${claudeArgs.join(' ')}`
-    const workingDir = cwd ?? process.cwd()
-
-    // macOS: use osascript to open Terminal.app and run command
     if (process.platform === 'darwin') {
-      // AppleScript to open new Terminal window, cd to directory, and run command
       const escapedDir = workingDir.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-      const escapedCmd = claudeCommand.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      const escapedCmd = command.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
       const script = `
 tell application "Terminal"
   activate
@@ -47,9 +36,8 @@ end tell
       return { success: true, pid: child.pid }
     }
 
-    // Windows: use start cmd
     if (process.platform === 'win32') {
-      const child = spawn('cmd', ['/c', 'start', 'cmd', '/k', claudeCommand], {
+      const child = spawn('cmd', ['/c', 'start', 'cmd', '/k', command], {
         cwd: workingDir,
         detached: true,
         stdio: 'ignore',
@@ -63,7 +51,7 @@ end tell
     const terminals = ['gnome-terminal', 'konsole', 'xterm']
     for (const term of terminals) {
       try {
-        const child = spawn(term, ['--', 'bash', '-c', `cd "${workingDir}" && ${claudeCommand}`], {
+        const child = spawn(term, ['--', 'bash', '-c', `cd "${workingDir}" && ${command}`], {
           detached: true,
           stdio: 'ignore',
         })
@@ -81,4 +69,22 @@ end tell
       error: error instanceof Error ? error.message : String(error),
     }
   }
+}
+
+/**
+ * Resume a session using claude CLI in an external terminal
+ */
+export const resumeSession = (options: ResumeSessionOptions): ResumeSessionResult => {
+  const { sessionId, cwd, fork = false, args = [] } = options
+
+  const claudeArgs = ['--resume', sessionId]
+  if (fork) {
+    claudeArgs.push('--fork-session')
+  }
+  claudeArgs.push(...args)
+
+  return startClaude({
+    command: `claude ${claudeArgs.join(' ')}`,
+    cwd,
+  })
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -6,5 +6,5 @@
  * Usage: import { resumeSession } from '@claude-sessions/core/server'
  */
 
-export { resumeSession } from './resume.js'
-export type { ResumeSessionOptions, ResumeSessionResult } from './types.js'
+export { resumeSession, startClaude } from './resume.js'
+export type { ResumeSessionOptions, ResumeSessionResult, StartClaudeOptions } from './types.js'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -391,6 +391,13 @@ export interface SessionSortOptions {
 // ============================================================================
 
 /** Options for resuming a session */
+export interface StartClaudeOptions {
+  /** Full CLI command to execute (e.g. "claude --resume abc123") */
+  command: string
+  /** Working directory */
+  cwd?: string
+}
+
 export interface ResumeSessionOptions {
   /** Session ID to resume */
   sessionId: string

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -109,6 +109,11 @@
         "icon": "$(terminal)"
       },
       {
+        "command": "claudeSessions.startClaudeInFolder",
+        "title": "Start Claude in Folder",
+        "icon": "$(play-circle)"
+      },
+      {
         "command": "claudeSessions.startClaudeYolo",
         "title": "Start Claude (YOLO)",
         "icon": "$(zap)"
@@ -282,9 +287,29 @@
           "group": "1_open"
         },
         {
+          "command": "claudeSessions.openTerminalHere",
+          "when": "view == claudeSessions && viewItem == project",
+          "group": "inline@3"
+        },
+        {
+          "command": "claudeSessions.startClaudeInFolder",
+          "when": "view == claudeSessions && viewItem == project",
+          "group": "2_claude"
+        },
+        {
+          "command": "claudeSessions.startClaudeInFolder",
+          "when": "view == claudeSessions && viewItem == project",
+          "group": "inline@4"
+        },
+        {
           "command": "claudeSessions.startClaudeYolo",
           "when": "view == claudeSessions && viewItem == project",
-          "group": "1_open"
+          "group": "2_claude"
+        },
+        {
+          "command": "claudeSessions.startClaudeYolo",
+          "when": "view == claudeSessions && viewItem == project",
+          "group": "inline@5"
         }
       ]
     },

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -704,6 +704,69 @@ export function activate(context: vscode.ExtensionContext) {
     ),
 
     vscode.commands.registerCommand(
+      'claudeSessions.startClaudeInFolder',
+      async (item: SessionTreeItem) => {
+        if (!item || (item.type !== 'session' && item.type !== 'project')) return
+
+        const { defaultTerminalMode, cliFlags } = getConfig()
+        const cliCommand = cliFlags ? `claude ${cliFlags}` : 'claude'
+        const cwd = await resolveProjectCwd(item.projectName)
+
+        let mode: 'internal' | 'external'
+        if (defaultTerminalMode === 'internal' || defaultTerminalMode === 'external') {
+          mode = defaultTerminalMode
+        } else {
+          const choice = await vscode.window.showQuickPick(
+            [
+              {
+                label: '$(terminal) Internal Terminal',
+                description: 'Open in VSCode integrated terminal',
+                mode: 'internal' as const,
+              },
+              {
+                label: '$(link-external) External Terminal',
+                description: 'Open in system default terminal',
+                mode: 'external' as const,
+              },
+            ],
+            {
+              placeHolder: 'Where to start Claude?',
+              title: 'Start Claude in Folder',
+            }
+          )
+
+          if (!choice) return
+          mode = choice.mode
+        }
+
+        if (mode === 'internal') {
+          const terminal = vscode.window.createTerminal({
+            name: `Claude: ${shortProjectName(item.projectName)}`,
+            cwd,
+          })
+          terminal.show()
+          terminal.sendText(cliCommand)
+        } else {
+          const args = cliFlags ? cliFlags.split(/\s+/).filter(Boolean) : []
+          const child = spawn('claude', args, {
+            cwd,
+            detached: true,
+            stdio: 'ignore',
+          })
+          child.unref()
+
+          if (child.pid) {
+            vscode.window.showInformationMessage(
+              `Claude started in external terminal (PID: ${child.pid})`
+            )
+          } else {
+            vscode.window.showErrorMessage('Failed to start Claude')
+          }
+        }
+      }
+    ),
+
+    vscode.commands.registerCommand(
       'claudeSessions.startClaudeYolo',
       async (item: SessionTreeItem) => {
         if (!item || (item.type !== 'session' && item.type !== 'project')) return

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { SessionTreeProvider, type SessionTreeItem } from './treeProvider'
 import * as session from '@claude-sessions/core'
-import { resumeSession } from '@claude-sessions/core/server'
+import { resumeSession, startClaude } from '@claude-sessions/core/server'
 import { Effect } from 'effect'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { outputChannel } from './output'
@@ -747,20 +747,14 @@ export function activate(context: vscode.ExtensionContext) {
           terminal.show()
           terminal.sendText(cliCommand)
         } else {
-          const args = cliFlags ? cliFlags.split(/\s+/).filter(Boolean) : []
-          const child = spawn('claude', args, {
-            cwd,
-            detached: true,
-            stdio: 'ignore',
-          })
-          child.unref()
+          const result = startClaude({ command: cliCommand, cwd })
 
-          if (child.pid) {
+          if (result.success) {
             vscode.window.showInformationMessage(
-              `Claude started in external terminal (PID: ${child.pid})`
+              `Claude started in external terminal (PID: ${result.pid})`
             )
           } else {
-            vscode.window.showErrorMessage('Failed to start Claude')
+            vscode.window.showErrorMessage(`Failed to start Claude: ${result.error}`)
           }
         }
       }


### PR DESCRIPTION
## Summary

- Cherry-pick `startClaudeInFolder` command from closed PR #82 (settings-aware Claude launch with internal/external terminal support)
- Promote 3 context-menu-only project commands to inline toolbar buttons:
  - `openTerminalHere` — open terminal in project folder
  - `startClaudeInFolder` — start Claude with `cliFlags` and `defaultTerminalMode` settings
  - `startClaudeYolo` — start Claude with `--dangerously-skip-permissions`
- Group Claude commands in separate `2_claude` context menu section

Closes #86 (vscode toolbar item)

## Test plan

- [x] Project item shows 3 new inline buttons (terminal, play-circle, zap icons)
- [x] Right-click project → "Start Claude in Folder" in `2_claude` group with separator
- [x] `startClaudeInFolder` with `defaultTerminalMode: "ask"` → shows internal/external picker
- [x] `startClaudeInFolder` with `defaultTerminalMode: "internal"` → opens in integrated terminal
- [x] `startClaudeInFolder` with `cliFlags` set → flags appended to command
- [x] `startClaudeYolo` still works as before
- [x] `openTerminalHere` toolbar button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Start Claude in Folder" command allowing users to launch Claude sessions from specific project folders via context menu.
  * Reorganized project context menus with improved action grouping, additional inline shortcuts, and enhanced structure for better accessibility and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->