### PR TITLE
feat(web): add compress session action to project tree list view

### DIFF
--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -228,8 +228,9 @@ export const moveSession = (sourceProject: string, sessionId: string, targetProj
 
 export interface CompressSessionResult {
   success: boolean
-  originalSize: number
   compressedSize: number
+  error?: string
+  originalSize: number
   removedCustomTitles: number
   removedProgress: number
   removedSnapshots: number

--- a/packages/web/src/lib/components/ProjectTree.svelte
+++ b/packages/web/src/lib/components/ProjectTree.svelte
@@ -357,7 +357,7 @@
 
                     <!-- Action buttons (visible on hover, absolute positioned) -->
                     <div
-                      class="absolute right-0 top-0 h-full flex items-center gap-0.5 pr-2 opacity-0 group-hover:opacity-100 transition-opacity bg-gh-bg"
+                      class="absolute right-0 top-0 h-full flex items-center gap-0.5 pr-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity bg-gh-bg"
                     >
                       {#if onResumeSession}
                         <TooltipButton

--- a/packages/web/src/lib/components/ProjectTree.svelte
+++ b/packages/web/src/lib/components/ProjectTree.svelte
@@ -30,9 +30,10 @@
     titleDisplayMode: TitleDisplayMode
     onToggleProject: (name: string) => void
     onSelectSession: (session: SessionMeta) => void
-    onRenameSession: (e: Event, session: SessionMeta) => void
+    onCompressSession?: (e: Event, session: SessionMeta) => void
     onDeleteSession: (e: Event, session: SessionMeta) => void
     onMoveSession?: (session: SessionMeta, targetProject: string) => void
+    onRenameSession: (e: Event, session: SessionMeta) => void
     onResumeSession?: (e: Event, session: SessionMeta) => void
     onSortChange?: (field: SessionSortField, order: SessionSortOrder) => void
     onTitleModeChange?: (mode: TitleDisplayMode) => void
@@ -50,9 +51,10 @@
     titleDisplayMode,
     onToggleProject,
     onSelectSession,
-    onRenameSession,
+    onCompressSession,
     onDeleteSession,
     onMoveSession,
+    onRenameSession,
     onResumeSession,
     onSortChange,
     onTitleModeChange,
@@ -373,6 +375,15 @@
                       >
                         ✏️
                       </TooltipButton>
+                      {#if onCompressSession}
+                        <TooltipButton
+                          class="p-1 rounded hover:bg-gh-accent/20 text-xs"
+                          onclick={(e) => onCompressSession(e, session)}
+                          title="Compress session"
+                        >
+                          🗜️
+                        </TooltipButton>
+                      {/if}
                       <TooltipButton
                         class="p-1 rounded hover:bg-gh-red/20 text-xs"
                         onclick={(e) => onDeleteSession(e, session)}

--- a/packages/web/src/lib/components/ProjectTree.svelte
+++ b/packages/web/src/lib/components/ProjectTree.svelte
@@ -377,6 +377,7 @@
                       </TooltipButton>
                       {#if onCompressSession}
                         <TooltipButton
+                          aria-label="Compress session"
                           class="p-1 rounded hover:bg-gh-accent/20 text-xs"
                           onclick={(e) => onCompressSession(e, session)}
                           title="Compress session"

--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -540,6 +540,32 @@
     }
   }
 
+  const handleCompressSession = (e: Event, session: SessionMeta) => {
+    e.stopPropagation()
+    showConfirm(
+      'Compress Session',
+      `Compress session "${session.title}"?\n\nThis will remove redundant data (progress messages and intermediate snapshots) to reduce file size. This action cannot be undone.`,
+      async () => {
+        closeConfirm()
+        try {
+          const result = await api.compressSession(session.projectName, session.id)
+          if (result.success) {
+            const saved =
+              result.originalSize > 0
+                ? Math.round((1 - result.compressedSize / result.originalSize) * 100)
+                : 0
+            toast = `Session compressed! Saved ~${saved}% (removed ${result.removedProgress} progress, ${result.removedSnapshots} snapshots)`
+            if (selectedSession?.id === session.id) {
+              messages = await api.getSession(session.projectName, session.id)
+            }
+          }
+        } catch (e) {
+          error = String(e)
+        }
+      }
+    )
+  }
+
   // Track if we've auto-expanded the current project
   let hasAutoExpanded = $state(false)
 
@@ -643,9 +669,10 @@
     {titleDisplayMode}
     onToggleProject={toggleProject}
     onSelectSession={selectSession}
-    onRenameSession={handleRenameSession}
+    onCompressSession={handleCompressSession}
     onDeleteSession={handleDeleteSession}
     onMoveSession={handleMoveSession}
+    onRenameSession={handleRenameSession}
     onResumeSession={handleResumeSession}
     onSortChange={handleSortChange}
     onTitleModeChange={handleTitleModeChange}

--- a/packages/web/src/routes/+page.svelte
+++ b/packages/web/src/routes/+page.svelte
@@ -548,6 +548,7 @@
       async () => {
         closeConfirm()
         try {
+          loading = true
           const result = await api.compressSession(session.projectName, session.id)
           if (result.success) {
             const saved =
@@ -558,9 +559,13 @@
             if (selectedSession?.id === session.id) {
               messages = await api.getSession(session.projectName, session.id)
             }
+          } else {
+            error = result.error ?? 'Failed to compress session'
           }
         } catch (e) {
           error = String(e)
+        } finally {
+          loading = false
         }
       }
     )


### PR DESCRIPTION
## Summary

- Add compress button to session row hover actions in ProjectTree
- Wire handleCompressSession handler in main page with confirm dialog and result toast
- Reloads messages if the compressed session is currently selected

Relates to #87

## Test plan

- [x] Hover over a session row — compress button appears between rename and delete
- [x] Click compress — confirm dialog appears with warning text
- [x] Confirm — session compresses, toast shows savings percentage
- [x] Compress while session is selected — messages reload with compressed content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session compression with confirmation modal before processing.
  * Shows approximate space savings and item removal counts after successful compression.
  * New "Compress session" button in the session action menu for quick access.
  * Action button now appears on focus as well as hover for improved keyboard accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->