### PR TITLE
feat(web): add persistent message type filter to session viewer

### DIFF
--- a/packages/web/src/lib/components/MessageFilter.stories.svelte
+++ b/packages/web/src/lib/components/MessageFilter.stories.svelte
@@ -1,0 +1,106 @@
+<script module>
+  import { defineMeta } from '@storybook/addon-svelte-csf'
+  import { fn } from 'storybook/test'
+  import MessageFilter from './MessageFilter.svelte'
+  import { DEFAULT_VISIBLE_CATEGORIES } from '$lib/utils'
+
+  const { Story } = defineMeta({
+    title: 'Components/MessageFilter',
+    component: MessageFilter,
+    tags: ['autodocs'],
+    parameters: {
+      layout: 'padded',
+    },
+  })
+
+  const sampleMessages = [
+    { uuid: '1', type: 'human', message: { content: 'Hello' } },
+    { uuid: '2', type: 'assistant', message: { content: [{ type: 'text', text: 'Hi there!' }] } },
+    {
+      uuid: '3',
+      type: 'assistant',
+      message: { content: [{ type: 'thinking', thinking: 'Let me think...' }] },
+    },
+    {
+      uuid: '4',
+      type: 'assistant',
+      message: {
+        content: [{ type: 'tool_use', id: 'tu1', name: 'Read', input: { path: '/tmp' } }],
+      },
+    },
+    {
+      uuid: '5',
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'file data' }] },
+    },
+    { uuid: '6', type: 'system', subtype: 'local_command', content: 'git status' },
+    { uuid: '7', type: 'summary', summary: 'Session summary text' },
+    { uuid: '8', type: 'user', message: { content: 'Another question' } },
+    {
+      uuid: '9',
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Another answer' }] },
+    },
+    { uuid: '10', type: 'progress', data: { type: 'hook_progress' } },
+  ]
+</script>
+
+<Story
+  name="Default Filter"
+  args={{
+    messages: sampleMessages,
+    visibleCategories: new Set(DEFAULT_VISIBLE_CATEGORIES),
+    onToggle: fn(),
+    onShowAll: fn(),
+    onReset: fn(),
+  }}
+>
+  {#snippet children(args)}
+    <div class="bg-gh-bg p-2">
+      <MessageFilter {...args} />
+    </div>
+  {/snippet}
+</Story>
+
+<Story
+  name="All Categories Visible"
+  args={{
+    messages: sampleMessages,
+    visibleCategories: new Set([
+      'user',
+      'assistant',
+      'thinking',
+      'tool_use',
+      'tool_result',
+      'system',
+      'summary',
+      'progress',
+    ]),
+    onToggle: fn(),
+    onShowAll: fn(),
+    onReset: fn(),
+  }}
+>
+  {#snippet children(args)}
+    <div class="bg-gh-bg p-2">
+      <MessageFilter {...args} />
+    </div>
+  {/snippet}
+</Story>
+
+<Story
+  name="Only User Messages"
+  args={{
+    messages: sampleMessages,
+    visibleCategories: new Set(['user']),
+    onToggle: fn(),
+    onShowAll: fn(),
+    onReset: fn(),
+  }}
+>
+  {#snippet children(args)}
+    <div class="bg-gh-bg p-2">
+      <MessageFilter {...args} />
+    </div>
+  {/snippet}
+</Story>

--- a/packages/web/src/lib/components/MessageFilter.svelte
+++ b/packages/web/src/lib/components/MessageFilter.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import type { Message } from '$lib/api'
+  import {
+    getMessageCategory,
+    MESSAGE_CATEGORY_LABELS,
+    DEFAULT_VISIBLE_CATEGORIES,
+    type MessageCategory,
+  } from '$lib/utils'
+
+  interface Props {
+    messages: Message[]
+    visibleCategories: Set<MessageCategory>
+    onToggle: (category: MessageCategory) => void
+    onShowAll: () => void
+    onReset: () => void
+  }
+
+  let { messages, visibleCategories, onToggle, onShowAll, onReset }: Props = $props()
+
+  const categoryCounts = $derived.by(() => {
+    const counts = new Map<MessageCategory, number>()
+    for (const msg of messages) {
+      const cat = getMessageCategory(msg)
+      counts.set(cat, (counts.get(cat) ?? 0) + 1)
+    }
+    return counts
+  })
+
+  const presentCategories = $derived(
+    (Object.keys(MESSAGE_CATEGORY_LABELS) as MessageCategory[]).filter(
+      (cat) => (categoryCounts.get(cat) ?? 0) > 0
+    )
+  )
+
+  const isDefault = $derived.by(() => {
+    if (visibleCategories.size !== DEFAULT_VISIBLE_CATEGORIES.length) return false
+    return DEFAULT_VISIBLE_CATEGORIES.every((c) => visibleCategories.has(c))
+  })
+
+  const isAll = $derived(presentCategories.every((c) => visibleCategories.has(c)))
+</script>
+
+{#if presentCategories.length > 1}
+  <div
+    class="flex items-center gap-1.5 px-4 py-2 bg-gh-bg border-b border-gh-border overflow-x-auto"
+  >
+    <div class="flex items-center gap-1 mr-1">
+      <button
+        class="px-2 py-0.5 text-xs rounded transition-colors {isAll
+          ? 'bg-gh-accent text-white'
+          : 'text-gh-text-secondary hover:text-gh-text hover:bg-gh-border-subtle'}"
+        onclick={onShowAll}
+      >
+        All
+      </button>
+      <button
+        class="px-2 py-0.5 text-xs rounded transition-colors {isDefault
+          ? 'bg-gh-accent text-white'
+          : 'text-gh-text-secondary hover:text-gh-text hover:bg-gh-border-subtle'}"
+        onclick={onReset}
+      >
+        Default
+      </button>
+    </div>
+    <div class="w-px h-4 bg-gh-border"></div>
+    <div class="flex items-center gap-1">
+      {#each presentCategories as category}
+        {@const active = visibleCategories.has(category)}
+        {@const count = categoryCounts.get(category) ?? 0}
+        <button
+          class="px-2 py-0.5 text-xs rounded transition-colors whitespace-nowrap {active
+            ? 'bg-gh-accent/20 text-gh-accent border border-gh-accent/40'
+            : 'text-gh-text-secondary hover:text-gh-text border border-transparent hover:border-gh-border'}"
+          onclick={() => onToggle(category)}
+        >
+          {MESSAGE_CATEGORY_LABELS[category]}
+          <span class="ml-0.5 opacity-60">{count}</span>
+        </button>
+      {/each}
+    </div>
+  </div>
+{/if}

--- a/packages/web/src/lib/components/SessionViewer.svelte
+++ b/packages/web/src/lib/components/SessionViewer.svelte
@@ -84,13 +84,27 @@
 
   // Message type filter with localStorage persistence
   const FILTER_STORAGE_KEY = 'claudeSessionsMessageTypeFilter'
-  const storedFilter =
-    typeof window !== 'undefined' ? localStorage.getItem(FILTER_STORAGE_KEY) : null
-  let visibleCategories = $state<Set<MessageCategory>>(
-    storedFilter ? new Set(JSON.parse(storedFilter)) : new Set(DEFAULT_VISIBLE_CATEGORIES)
-  )
+  const getInitialVisibleCategories = (): Set<MessageCategory> => {
+    if (typeof window === 'undefined') return new Set(DEFAULT_VISIBLE_CATEGORIES)
+    const stored = localStorage.getItem(FILTER_STORAGE_KEY)
+    if (!stored) return new Set(DEFAULT_VISIBLE_CATEGORIES)
+    try {
+      const parsed = JSON.parse(stored)
+      if (!Array.isArray(parsed)) return new Set(DEFAULT_VISIBLE_CATEGORIES)
+      const valid = parsed.filter(
+        (c): c is MessageCategory =>
+          typeof c === 'string' && DEFAULT_VISIBLE_CATEGORIES.includes(c as MessageCategory)
+      )
+      return valid.length > 0 ? new Set(valid) : new Set(DEFAULT_VISIBLE_CATEGORIES)
+    } catch {
+      return new Set(DEFAULT_VISIBLE_CATEGORIES)
+    }
+  }
+  let visibleCategories = $state<Set<MessageCategory>>(getInitialVisibleCategories())
   $effect(() => {
-    localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify([...visibleCategories]))
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify([...visibleCategories]))
+    }
   })
 
   const filteredMessages = $derived(

--- a/packages/web/src/lib/components/SessionViewer.svelte
+++ b/packages/web/src/lib/components/SessionViewer.svelte
@@ -13,7 +13,12 @@
   import ValidationBadge from './ValidationBadge.svelte'
   import CommandTitle from './CommandTitle.svelte'
   import SessionActions from './SessionActions.svelte'
-  import { getMessageCategory, DEFAULT_VISIBLE_CATEGORIES, type MessageCategory } from '$lib/utils'
+  import {
+    ALL_MESSAGE_CATEGORIES,
+    getMessageCategory,
+    DEFAULT_VISIBLE_CATEGORIES,
+    type MessageCategory,
+  } from '$lib/utils'
 
   // Tab type - messages, todos, or agent:<agentId>
   type TabType = 'messages' | 'todos' | `agent:${string}`
@@ -93,7 +98,7 @@
       if (!Array.isArray(parsed)) return new Set(DEFAULT_VISIBLE_CATEGORIES)
       const valid = parsed.filter(
         (c): c is MessageCategory =>
-          typeof c === 'string' && DEFAULT_VISIBLE_CATEGORIES.includes(c as MessageCategory)
+          typeof c === 'string' && ALL_MESSAGE_CATEGORIES.includes(c as MessageCategory)
       )
       return valid.length > 0 ? new Set(valid) : new Set(DEFAULT_VISIBLE_CATEGORIES)
     } catch {
@@ -170,10 +175,7 @@
   )
 
   const handleFilterShowAll = () => {
-    const allCategories = new Set<MessageCategory>()
-    for (const msg of messages) allCategories.add(getMessageCategory(msg))
-    for (const msg of agentMessages) allCategories.add(getMessageCategory(msg))
-    visibleCategories = allCategories
+    visibleCategories = new Set(ALL_MESSAGE_CATEGORIES)
   }
 
   // Undo stack - stores already-deleted messages that can be restored

--- a/packages/web/src/lib/components/SessionViewer.svelte
+++ b/packages/web/src/lib/components/SessionViewer.svelte
@@ -7,11 +7,13 @@
   import type { AgentInfo, Message, SessionMeta, TodoItem } from '$lib/api'
   import * as api from '$lib/api'
   import { getDisplayTitle, truncate } from '$lib/utils'
+  import MessageFilter from './MessageFilter.svelte'
   import MessageList from './MessageList.svelte'
   import ScrollButtons from './ScrollButtons.svelte'
   import ValidationBadge from './ValidationBadge.svelte'
   import CommandTitle from './CommandTitle.svelte'
   import SessionActions from './SessionActions.svelte'
+  import { getMessageCategory, DEFAULT_VISIBLE_CATEGORIES, type MessageCategory } from '$lib/utils'
 
   // Tab type - messages, todos, or agent:<agentId>
   type TabType = 'messages' | 'todos' | `agent:${string}`
@@ -80,6 +82,35 @@
   )
   let isRepairing = $state(false)
 
+  // Message type filter with localStorage persistence
+  const FILTER_STORAGE_KEY = 'claudeSessionsMessageTypeFilter'
+  const storedFilter =
+    typeof window !== 'undefined' ? localStorage.getItem(FILTER_STORAGE_KEY) : null
+  let visibleCategories = $state<Set<MessageCategory>>(
+    storedFilter ? new Set(JSON.parse(storedFilter)) : new Set(DEFAULT_VISIBLE_CATEGORIES)
+  )
+  $effect(() => {
+    localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify([...visibleCategories]))
+  })
+
+  const filteredMessages = $derived(
+    messages.filter((m) => visibleCategories.has(getMessageCategory(m)))
+  )
+
+  const handleFilterToggle = (category: MessageCategory) => {
+    const next = new Set(visibleCategories)
+    if (next.has(category)) {
+      next.delete(category)
+    } else {
+      next.add(category)
+    }
+    visibleCategories = next
+  }
+
+  const handleFilterReset = () => {
+    visibleCategories = new Set(DEFAULT_VISIBLE_CATEGORIES)
+  }
+
   const handleRepairChain = async () => {
     if (!session || isRepairing) return
     isRepairing = true
@@ -119,6 +150,17 @@
   let activeTab = $state<TabType>('messages')
   let agentMessages = $state<Message[]>([])
   let loadingAgent = $state(false)
+
+  const filteredAgentMessages = $derived(
+    agentMessages.filter((m) => visibleCategories.has(getMessageCategory(m)))
+  )
+
+  const handleFilterShowAll = () => {
+    const allCategories = new Set<MessageCategory>()
+    for (const msg of messages) allCategories.add(getMessageCategory(msg))
+    for (const msg of agentMessages) allCategories.add(getMessageCategory(msg))
+    visibleCategories = allCategories
+  }
 
   // Undo stack - stores already-deleted messages that can be restored
   interface DeletedMessage {
@@ -406,7 +448,9 @@
             : 'text-gh-text-secondary hover:text-gh-text hover:bg-gh-border-subtle'}"
           onclick={() => (activeTab = 'messages')}
         >
-          💬 Messages ({messages.length})
+          💬 Messages ({filteredMessages.length}{filteredMessages.length !== messages.length
+            ? `/${messages.length}`
+            : ''})
         </button>
         {#each agents as agent}
           <button
@@ -437,6 +481,17 @@
     </div>
   {/if}
 
+  <!-- Message Type Filter -->
+  {#if session && (activeTab === 'messages' || activeTab.startsWith('agent:'))}
+    <MessageFilter
+      messages={activeTab === 'messages' ? messages : agentMessages}
+      {visibleCategories}
+      onToggle={handleFilterToggle}
+      onShowAll={handleFilterShowAll}
+      onReset={handleFilterReset}
+    />
+  {/if}
+
   <!-- Content -->
   <div bind:this={internalScrollContainer} class="flex-1 {enableScroll ? 'overflow-y-auto' : ''}">
     {#if !session}
@@ -451,7 +506,7 @@
       {:else}
         <MessageList
           sessionId={session.id}
-          {messages}
+          messages={filteredMessages}
           onDeleteMessage={handleSessionMessageDelete}
           {onEditTitle}
           {onSplitSession}
@@ -497,7 +552,7 @@
       {:else}
         <MessageList
           sessionId={session.id}
-          messages={agentMessages}
+          messages={filteredAgentMessages}
           onDeleteMessage={handleAgentMessageDelete}
           enableScroll={false}
           fullWidth={true}

--- a/packages/web/src/lib/components/SessionViewer.svelte
+++ b/packages/web/src/lib/components/SessionViewer.svelte
@@ -92,7 +92,7 @@
   const getInitialVisibleCategories = (): Set<MessageCategory> => {
     if (typeof window === 'undefined') return new Set(DEFAULT_VISIBLE_CATEGORIES)
     const stored = localStorage.getItem(FILTER_STORAGE_KEY)
-    if (!stored) return new Set(DEFAULT_VISIBLE_CATEGORIES)
+    if (stored === null) return new Set(DEFAULT_VISIBLE_CATEGORIES)
     try {
       const parsed = JSON.parse(stored)
       if (!Array.isArray(parsed)) return new Set(DEFAULT_VISIBLE_CATEGORIES)
@@ -100,7 +100,7 @@
         (c): c is MessageCategory =>
           typeof c === 'string' && ALL_MESSAGE_CATEGORIES.includes(c as MessageCategory)
       )
-      return valid.length > 0 ? new Set(valid) : new Set(DEFAULT_VISIBLE_CATEGORIES)
+      return new Set(valid)
     } catch {
       return new Set(DEFAULT_VISIBLE_CATEGORIES)
     }

--- a/packages/web/src/lib/utils/message.test.ts
+++ b/packages/web/src/lib/utils/message.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { maskHomePath } from '$lib/stores/config'
 import {
+  ALL_MESSAGE_CATEGORIES,
   getMessageCategory,
   DEFAULT_VISIBLE_CATEGORIES,
+  MESSAGE_CATEGORY_LABELS,
   parseCommandMessage,
   parseProgress,
   parseStopHookSummary,
@@ -114,11 +116,24 @@ describe('getMessageCategory', () => {
   })
 })
 
+describe('ALL_MESSAGE_CATEGORIES', () => {
+  it('should contain all keys from MESSAGE_CATEGORY_LABELS', () => {
+    expect(ALL_MESSAGE_CATEGORIES).toEqual(Object.keys(MESSAGE_CATEGORY_LABELS))
+  })
+
+  it('should include every DEFAULT_VISIBLE_CATEGORIES entry', () => {
+    for (const cat of DEFAULT_VISIBLE_CATEGORIES) {
+      expect(ALL_MESSAGE_CATEGORIES).toContain(cat)
+    }
+  })
+})
+
 describe('DEFAULT_VISIBLE_CATEGORIES', () => {
-  it('should include user, assistant, and summary by default', () => {
+  it('should include user, assistant, summary, and metadata by default', () => {
     expect(DEFAULT_VISIBLE_CATEGORIES).toContain('user')
     expect(DEFAULT_VISIBLE_CATEGORIES).toContain('assistant')
     expect(DEFAULT_VISIBLE_CATEGORIES).toContain('summary')
+    expect(DEFAULT_VISIBLE_CATEGORIES).toContain('metadata')
   })
 
   it('should not include thinking or tool types by default', () => {

--- a/packages/web/src/lib/utils/message.test.ts
+++ b/packages/web/src/lib/utils/message.test.ts
@@ -1,11 +1,132 @@
 import { describe, it, expect } from 'vitest'
 import { maskHomePath } from '$lib/stores/config'
 import {
+  getMessageCategory,
+  DEFAULT_VISIBLE_CATEGORIES,
   parseCommandMessage,
   parseProgress,
   parseStopHookSummary,
   parseTurnDuration,
 } from './message'
+import type { Message } from '$lib/api'
+
+const makeMsg = (overrides: Partial<Message>): Message => ({
+  uuid: 'test-uuid',
+  type: 'user',
+  ...overrides,
+})
+
+describe('getMessageCategory', () => {
+  it('should categorize human messages as user', () => {
+    expect(getMessageCategory(makeMsg({ type: 'human' }))).toBe('user')
+  })
+
+  it('should categorize user messages without tool_result as user', () => {
+    const msg = makeMsg({ type: 'user', message: { content: 'hello' } })
+    expect(getMessageCategory(msg)).toBe('user')
+  })
+
+  it('should categorize user messages with tool_result content as tool_result', () => {
+    const msg = makeMsg({
+      type: 'user',
+      message: { content: [{ type: 'tool_result', tool_use_id: 'id', content: 'result' }] },
+    })
+    expect(getMessageCategory(msg)).toBe('tool_result')
+  })
+
+  it('should categorize plain assistant text as assistant', () => {
+    const msg = makeMsg({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'Hello!' }] },
+    })
+    expect(getMessageCategory(msg)).toBe('assistant')
+  })
+
+  it('should categorize assistant with tool_use as tool_use', () => {
+    const msg = makeMsg({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'text', text: 'Let me check...' },
+          { type: 'tool_use', id: 'tu1', name: 'Read', input: {} },
+        ],
+      },
+    })
+    expect(getMessageCategory(msg)).toBe('tool_use')
+  })
+
+  it('should categorize assistant with only thinking as thinking', () => {
+    const msg = makeMsg({
+      type: 'assistant',
+      message: { content: [{ type: 'thinking', thinking: 'hmm...' }] },
+    })
+    expect(getMessageCategory(msg)).toBe('thinking')
+  })
+
+  it('should categorize assistant with text + thinking as assistant (text takes priority)', () => {
+    const msg = makeMsg({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'thinking', thinking: 'hmm...' },
+          { type: 'text', text: 'Here is the answer' },
+        ],
+      },
+    })
+    expect(getMessageCategory(msg)).toBe('assistant')
+  })
+
+  it('should categorize system messages as system', () => {
+    expect(getMessageCategory(makeMsg({ type: 'system', subtype: 'local_command' }))).toBe('system')
+  })
+
+  it('should categorize summary messages as summary', () => {
+    expect(getMessageCategory(makeMsg({ type: 'summary' }))).toBe('summary')
+  })
+
+  it('should categorize progress messages as progress', () => {
+    expect(getMessageCategory(makeMsg({ type: 'progress' }))).toBe('progress')
+  })
+
+  it('should categorize agent-name as metadata', () => {
+    expect(getMessageCategory(makeMsg({ type: 'agent-name' }))).toBe('metadata')
+  })
+
+  it('should categorize custom-title as metadata', () => {
+    expect(getMessageCategory(makeMsg({ type: 'custom-title' }))).toBe('metadata')
+  })
+
+  it('should categorize compact_boundary as metadata', () => {
+    expect(getMessageCategory(makeMsg({ type: 'compact_boundary' }))).toBe('metadata')
+  })
+
+  it('should categorize file-history-snapshot as metadata', () => {
+    expect(getMessageCategory(makeMsg({ type: 'file-history-snapshot' }))).toBe('metadata')
+  })
+
+  it('should categorize queue-operation as metadata', () => {
+    expect(getMessageCategory(makeMsg({ type: 'queue-operation' }))).toBe('metadata')
+  })
+
+  it('should categorize assistant without content array as assistant', () => {
+    const msg = makeMsg({ type: 'assistant', message: { content: 'plain string' } })
+    expect(getMessageCategory(msg)).toBe('assistant')
+  })
+})
+
+describe('DEFAULT_VISIBLE_CATEGORIES', () => {
+  it('should include user, assistant, and summary by default', () => {
+    expect(DEFAULT_VISIBLE_CATEGORIES).toContain('user')
+    expect(DEFAULT_VISIBLE_CATEGORIES).toContain('assistant')
+    expect(DEFAULT_VISIBLE_CATEGORIES).toContain('summary')
+  })
+
+  it('should not include thinking or tool types by default', () => {
+    expect(DEFAULT_VISIBLE_CATEGORIES).not.toContain('thinking')
+    expect(DEFAULT_VISIBLE_CATEGORIES).not.toContain('tool_use')
+    expect(DEFAULT_VISIBLE_CATEGORIES).not.toContain('tool_result')
+  })
+})
 
 describe('maskHomePath', () => {
   const homeDir = '/Users/david'

--- a/packages/web/src/lib/utils/message.ts
+++ b/packages/web/src/lib/utils/message.ts
@@ -5,6 +5,68 @@
 import type { Content, Message } from '$lib/api'
 import { maskHomePath } from '$lib/stores/config'
 
+export type MessageCategory =
+  | 'assistant'
+  | 'metadata'
+  | 'progress'
+  | 'summary'
+  | 'system'
+  | 'thinking'
+  | 'tool_result'
+  | 'tool_use'
+  | 'user'
+
+const METADATA_TYPES = new Set([
+  'agent-name',
+  'compact_boundary',
+  'custom-title',
+  'file-history-snapshot',
+  'queue-operation',
+])
+
+export const getMessageCategory = (msg: Message): MessageCategory => {
+  if (METADATA_TYPES.has(msg.type)) return 'metadata'
+  if (msg.type === 'progress') return 'progress'
+  if (msg.type === 'summary') return 'summary'
+  if (msg.type === 'system') return 'system'
+  if (msg.type === 'human') return 'user'
+
+  if (msg.type === 'user') {
+    const m = msg.message as { content?: unknown[] } | undefined
+    if (Array.isArray(m?.content)) {
+      const first = m.content[0] as { type?: string } | undefined
+      if (first?.type === 'tool_result') return 'tool_result'
+    }
+    return 'user'
+  }
+
+  if (msg.type === 'assistant') {
+    const m = msg.message as { content?: Array<Record<string, unknown>> } | undefined
+    if (Array.isArray(m?.content)) {
+      if (m.content.some((c) => c?.type === 'tool_use')) return 'tool_use'
+      const hasText = m.content.some((c) => c?.type === 'text' && (c?.text as string)?.trim())
+      if (!hasText && m.content.some((c) => c?.type === 'thinking')) return 'thinking'
+    }
+    return 'assistant'
+  }
+
+  return 'metadata'
+}
+
+export const MESSAGE_CATEGORY_LABELS: Record<MessageCategory, string> = {
+  assistant: 'Assistant',
+  metadata: 'Metadata',
+  progress: 'Progress',
+  summary: 'Summary',
+  system: 'System',
+  thinking: 'Thinking',
+  tool_result: 'Tool Result',
+  tool_use: 'Tool Use',
+  user: 'User',
+}
+
+export const DEFAULT_VISIBLE_CATEGORIES: MessageCategory[] = ['assistant', 'summary', 'user']
+
 /**
  * Replace home directory paths with ~ in text content
  * Uses current user's home directory from appConfig store

--- a/packages/web/src/lib/utils/message.ts
+++ b/packages/web/src/lib/utils/message.ts
@@ -65,7 +65,12 @@ export const MESSAGE_CATEGORY_LABELS: Record<MessageCategory, string> = {
   user: 'User',
 }
 
-export const DEFAULT_VISIBLE_CATEGORIES: MessageCategory[] = ['assistant', 'summary', 'user']
+export const DEFAULT_VISIBLE_CATEGORIES: MessageCategory[] = [
+  'assistant',
+  'metadata',
+  'summary',
+  'user',
+]
 
 /**
  * Replace home directory paths with ~ in text content

--- a/packages/web/src/lib/utils/message.ts
+++ b/packages/web/src/lib/utils/message.ts
@@ -65,6 +65,8 @@ export const MESSAGE_CATEGORY_LABELS: Record<MessageCategory, string> = {
   user: 'User',
 }
 
+export const ALL_MESSAGE_CATEGORIES = Object.keys(MESSAGE_CATEGORY_LABELS) as MessageCategory[]
+
 export const DEFAULT_VISIBLE_CATEGORIES: MessageCategory[] = [
   'assistant',
   'metadata',


### PR DESCRIPTION
## Summary
- Add MessageFilter component with chip-style toggle buttons for filtering session messages by category
- Categories: User, Assistant, Thinking, Tool Use, Tool Result, System, Summary, Metadata, Progress
- Default filter shows User + Assistant + Summary messages (others hidden)
- Filter state persists across page loads via localStorage
- Filter applies to both main messages tab and agent messages tab
- Messages tab header shows filtered/total count when filter is active
- Add getMessageCategory utility with comprehensive unit tests (18 test cases)

Relates to #94

## Test plan
- [x] Open a session with mixed message types (user, assistant, tool_use, thinking)
- [x] Verify default filter shows only User, Assistant, Summary messages
- [x] Toggle Thinking category — thinking blocks appear
- [x] Toggle Tool Use — tool call messages appear
- [x] Click All — all message types visible
- [x] Click Default — reset to default filter
- [x] Reload page — filter settings persist
- [x] Switch to agent tab — same filter applies
- [x] Verify in Storybook: MessageFilter component stories render correctly

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message filtering UI to show/hide messages by category with per-category counts, "All" and "Default" quick buttons, and filtered/total counts in the Messages tab.
  * Filter state persists across sessions and is integrated into the session viewer.

* **Documentation**
  * Added interactive component examples demonstrating filter states and presets.

* **Tests**
  * Unit tests for message category classification, category lists, and default visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->