### PR TITLE
test(vscode): add test:vsx root script and web server HTTP 200 test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:core": "pnpm --filter @claude-sessions/core test",
     "test:e2e": "pnpm --filter @claude-sessions/web exec playwright test",
     "test:mcp": "pnpm --filter claude-sessions-mcp test",
+    "test:vsx": "pnpm --filter claude-sessions test",
     "test:web": "pnpm --filter @claude-sessions/web test",
     "typecheck": "pnpm -r typecheck",
     "prepare": "husky",

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -60,8 +60,7 @@ suite('Webview Test Suite', () => {
     // Get the extension
     const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
     if (!extension) {
-      console.log('Extension not found, skipping test')
-      return
+      assert.fail('Extension not found: es6kr.claude-sessions')
     }
 
     // Activate extension if not already active
@@ -100,8 +99,7 @@ suite('Webview Test Suite', () => {
     // Get the extension
     const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
     if (!extension) {
-      console.log('Extension not found, skipping test')
-      return
+      assert.fail('Extension not found: es6kr.claude-sessions')
     }
 
     // Activate extension if not already active
@@ -161,8 +159,7 @@ suite('Webview Test Suite', () => {
     // Get the extension
     const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
     if (!extension) {
-      console.log('Extension not found, skipping test')
-      return
+      assert.fail('Extension not found: es6kr.claude-sessions')
     }
 
     // Activate extension if not already active
@@ -203,8 +200,7 @@ suite('Webview Test Suite', () => {
     // Get the extension
     const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
     if (!extension) {
-      console.log('Extension not found, skipping test')
-      return
+      assert.fail('Extension not found: es6kr.claude-sessions')
     }
 
     // Activate extension if not already active
@@ -280,7 +276,7 @@ suite('Webview Test Suite', () => {
       }
     }
 
-    console.log(`Web server /api/version responded: ${statusCode} ${body}`)
+    console.log(`Web server /api/version responded with status: ${statusCode}`)
     assert.strictEqual(statusCode, 200, 'Web server should respond with HTTP 200')
     const parsed = JSON.parse(body)
     assert.ok(parsed.version, 'Response should contain version field')

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -42,6 +42,12 @@ function createMockSessionTreeItem(projectName: string, sessionId: string) {
 }
 
 suite('Webview Test Suite', () => {
+  // Restore webServerPath after tests that override it
+  suiteTeardown(async () => {
+    const config = vscode.workspace.getConfiguration('claudeSessions')
+    await config.update('webServerPath', undefined, vscode.ConfigurationTarget.Global)
+  })
+
   test('Commands are registered', async function () {
     this.timeout(30000)
 
@@ -242,6 +248,15 @@ suite('Webview Test Suite', () => {
     }
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
+    // Use local build instead of npx to test current source
+    // __dirname = packages/vscode-extension/out/test/suite (compiled)
+    const webBuildPath = path.resolve(__dirname, '../../../../web/build/index.js')
+    if (fs.existsSync(webBuildPath)) {
+      const config = vscode.workspace.getConfiguration('claudeSessions')
+      await config.update('webServerPath', webBuildPath, vscode.ConfigurationTarget.Global)
+      console.log(`Using local web build: ${webBuildPath}`)
+    }
+
     await vscode.commands.executeCommand('claudeSessions.restartWebServer')
     console.log('restartWebServer executed, polling for server readiness...')
 
@@ -302,6 +317,14 @@ suite('Webview Test Suite', () => {
       await extension.activate()
     }
     await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // Use local build instead of npx to test current source
+    const webBuildPath = path.resolve(__dirname, '../../../../web/build/index.js')
+    if (fs.existsSync(webBuildPath)) {
+      const config = vscode.workspace.getConfiguration('claudeSessions')
+      await config.update('webServerPath', webBuildPath, vscode.ConfigurationTarget.Global)
+      console.log(`Using local web build: ${webBuildPath}`)
+    }
 
     // Ensure web server is running (reuse from previous test or start fresh)
     await vscode.commands.executeCommand('claudeSessions.restartWebServer')

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode'
 import * as assert from 'assert'
 import * as fs from 'fs'
+import * as http from 'http'
 import * as path from 'path'
 import * as os from 'os'
 
@@ -222,5 +223,54 @@ suite('Webview Test Suite', () => {
     } catch (err) {
       assert.fail(`openWebUI command failed: ${err}`)
     }
+  })
+
+  test('Web server responds with HTTP 200', async function () {
+    if (process.env.CI) {
+      console.log('Skipping web server HTTP test in CI environment')
+      this.skip()
+      return
+    }
+
+    this.timeout(60000)
+
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
+    if (!extension) {
+      console.log('Extension not found, skipping test')
+      return
+    }
+
+    if (!extension.isActive) {
+      await extension.activate()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await vscode.commands.executeCommand('claudeSessions.openWebUI')
+    console.log('openWebUI executed, waiting for server to be ready...')
+
+    await new Promise((resolve) => setTimeout(resolve, 5000))
+
+    const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
+    const { statusCode, body } = await new Promise<{ statusCode: number; body: string }>(
+      (resolve, reject) => {
+        const req = http.get(`http://localhost:${port}/api/version`, (res) => {
+          let data = ''
+          res.on('data', (chunk: Buffer) => (data += chunk.toString()))
+          res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body: data }))
+        })
+        req.on('error', reject)
+        req.setTimeout(10000, () => {
+          req.destroy()
+          reject(new Error('HTTP request timeout'))
+        })
+      }
+    )
+
+    console.log(`Web server /api/version responded: ${statusCode} ${body}`)
+    assert.strictEqual(statusCode, 200, 'Web server should respond with HTTP 200')
+    const parsed = JSON.parse(body)
+    assert.ok(parsed.version, 'Response should contain version field')
   })
 })

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -238,8 +238,7 @@ suite('Webview Test Suite', () => {
 
     const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
     if (!extension) {
-      console.log('Extension not found, skipping test')
-      return
+      assert.fail('Extension not found: es6kr.claude-sessions')
     }
 
     if (!extension.isActive) {
@@ -247,26 +246,39 @@ suite('Webview Test Suite', () => {
     }
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
-    await vscode.commands.executeCommand('claudeSessions.openWebUI')
-    console.log('openWebUI executed, waiting for server to be ready...')
-
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    await vscode.commands.executeCommand('claudeSessions.restartWebServer')
+    console.log('restartWebServer executed, polling for server readiness...')
 
     const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
-    const { statusCode, body } = await new Promise<{ statusCode: number; body: string }>(
-      (resolve, reject) => {
-        const req = http.get(`http://localhost:${port}/api/version`, (res) => {
-          let data = ''
-          res.on('data', (chunk: Buffer) => (data += chunk.toString()))
-          res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body: data }))
-        })
-        req.on('error', reject)
-        req.setTimeout(10000, () => {
-          req.destroy()
-          reject(new Error('HTTP request timeout'))
-        })
+    const maxRetries = 10
+    const retryInterval = 1000
+    let statusCode = 0
+    let body = ''
+
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const result = await new Promise<{ statusCode: number; body: string }>(
+          (resolve, reject) => {
+            const req = http.get(`http://localhost:${port}/api/version`, (res) => {
+              let data = ''
+              res.on('data', (chunk: Buffer) => (data += chunk.toString()))
+              res.on('end', () => resolve({ statusCode: res.statusCode ?? 0, body: data }))
+            })
+            req.on('error', reject)
+            req.setTimeout(3000, () => {
+              req.destroy()
+              reject(new Error('HTTP request timeout'))
+            })
+          }
+        )
+        statusCode = result.statusCode
+        body = result.body
+        break
+      } catch {
+        console.log(`Retry ${i + 1}/${maxRetries}: server not ready yet`)
+        await new Promise((resolve) => setTimeout(resolve, retryInterval))
       }
-    )
+    }
 
     console.log(`Web server /api/version responded: ${statusCode} ${body}`)
     assert.strictEqual(statusCode, 200, 'Web server should respond with HTTP 200')

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -281,4 +281,75 @@ suite('Webview Test Suite', () => {
     const parsed = JSON.parse(body)
     assert.ok(parsed.version, 'Response should contain version field')
   })
+
+  test('Frontend root path responds with HTTP 200', async function () {
+    if (process.env.CI) {
+      console.log('Skipping frontend root test in CI environment')
+      this.skip()
+      return
+    }
+
+    this.timeout(60000)
+
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
+    if (!extension) {
+      assert.fail('Extension not found: es6kr.claude-sessions')
+    }
+
+    if (!extension.isActive) {
+      await extension.activate()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // Ensure web server is running (reuse from previous test or start fresh)
+    await vscode.commands.executeCommand('claudeSessions.restartWebServer')
+    console.log('restartWebServer executed, polling for server readiness...')
+
+    const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
+
+    // Wait for /api/version first (server is ready)
+    const maxRetries = 10
+    const retryInterval = 1000
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const result = await new Promise<{ statusCode: number }>((resolve, reject) => {
+          const req = http.get(`http://localhost:${port}/api/version`, (res) => {
+            res.resume()
+            res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
+          })
+          req.on('error', reject)
+          req.setTimeout(3000, () => {
+            req.destroy()
+            reject(new Error('timeout'))
+          })
+        })
+        if (result.statusCode === 200) break
+      } catch {
+        console.log(`Retry ${i + 1}/${maxRetries}: server not ready yet`)
+        await new Promise((resolve) => setTimeout(resolve, retryInterval))
+      }
+    }
+
+    // Now test the frontend root path
+    const rootResult = await new Promise<{ statusCode: number }>((resolve, reject) => {
+      const req = http.get(`http://localhost:${port}/`, (res) => {
+        res.resume()
+        res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
+      })
+      req.on('error', reject)
+      req.setTimeout(5000, () => {
+        req.destroy()
+        reject(new Error('Root path request timeout'))
+      })
+    })
+
+    console.log(`Web server / responded with status: ${rootResult.statusCode}`)
+    assert.strictEqual(
+      rootResult.statusCode,
+      200,
+      `Frontend root path should respond with HTTP 200, got ${rootResult.statusCode}`
+    )
+  })
 })

--- a/packages/web/src/lib/stores/theme.ts
+++ b/packages/web/src/lib/stores/theme.ts
@@ -1,17 +1,22 @@
 import { writable, derived } from 'svelte/store'
+import { browser } from '$app/environment'
 
 export type ThemePreference = 'light' | 'dark' | 'system'
 export type EffectiveTheme = 'light' | 'dark'
 
 const getStoredPreference = (): ThemePreference => {
-  if (typeof window === 'undefined') return 'system'
-  const stored = localStorage.getItem('theme')
-  if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
+  if (!browser) return 'system'
+  try {
+    const stored = localStorage.getItem('theme')
+    if (stored === 'light' || stored === 'dark' || stored === 'system') return stored
+  } catch {
+    // localStorage unavailable (Node.js with broken --localstorage-file)
+  }
   return 'system'
 }
 
 const getSystemTheme = (): EffectiveTheme => {
-  if (typeof window === 'undefined') return 'dark'
+  if (!browser) return 'dark'
   return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
 }
 
@@ -52,8 +57,12 @@ export const initTheme = () => {
 
   // Persist preference changes
   const unsubPref = themePreference.subscribe((pref) => {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('theme', pref)
+    if (browser) {
+      try {
+        localStorage.setItem('theme', pref)
+      } catch {
+        // localStorage unavailable
+      }
     }
   })
 


### PR DESCRIPTION
## Summary

- Add `test:vsx` script to root `package.json` for running vscode-extension tests via pnpm workspace filter
- Add HTTP 200 response verification test to `webview.test.ts` that verifies `/api/version` endpoint responds correctly after web server startup

## Test plan

- [x] `pnpm test:vsx` runs vscode-extension tests successfully (local only, CI skipped)
- [x] New "Web server responds with HTTP 200" test passes — verifies `/api/version` returns 200 with version field

Relates to #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added HTTP reachability tests to verify extension web server functionality with automatic retries and CI guards.
  * Enhanced test error handling for missing extensions.

* **Bug Fixes**
  * Improved theme preference storage with graceful fallback when local storage is unavailable.

* **Chores**
  * Added dedicated test script for VSCode extension testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->