### PR TITLE
fix(core): deduplicate agent-name/custom-title records after compact

### DIFF
--- a/packages/core/src/session/cleanup.test.ts
+++ b/packages/core/src/session/cleanup.test.ts
@@ -19,7 +19,7 @@ vi.mock('../todos.js', async () => ({
   deleteLinkedTodos: vi.fn(() => Effect.succeed({ deletedCount: 0 })),
 }))
 
-import { clearSessions } from './cleanup.js'
+import { clearSessions, deduplicateTitleRecords } from './cleanup.js'
 import { getSessionsDir } from '../paths.js'
 
 function makeMessage(overrides: Record<string, unknown> = {}) {
@@ -189,6 +189,169 @@ describe('clearSessions', () => {
       expect(result.removedMessageCount).toBe(0)
       const remaining = await readSession(tempDir, projectName, 'session-1')
       expect(remaining).toHaveLength(1)
+    })
+  })
+
+  describe('deduplicateTitleRecords (via clearSessions)', () => {
+    it('should remove duplicate agent-name records keeping the last', async () => {
+      const agentName1 = { type: 'agent-name', agentName: 'Task Agent', sessionId: 'session-1' }
+      const msg1 = makeMessage({ uuid: 'msg-1' })
+      const msg2 = makeMessage({ uuid: 'msg-2', type: 'assistant', parentUuid: 'msg-1' })
+      const agentName2 = { type: 'agent-name', agentName: 'Task Agent', sessionId: 'session-1' }
+      await writeSession(tempDir, projectName, 'session-1', [agentName1, msg1, msg2, agentName2])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          projectName,
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          deduplicateTitles: true,
+        })
+      )
+
+      expect(result.deduplicatedRecordCount).toBe(1)
+      const remaining = await readSession(tempDir, projectName, 'session-1')
+      expect(remaining).toHaveLength(3) // msg1, msg2, agentName2
+      expect(remaining.filter((r: { type: string }) => r.type === 'agent-name')).toHaveLength(1)
+    })
+
+    it('should remove duplicate custom-title records keeping the last', async () => {
+      const title1 = { type: 'custom-title', customTitle: 'My Session', sessionId: 'session-1' }
+      const msg1 = makeMessage({ uuid: 'msg-1' })
+      const title2 = { type: 'custom-title', customTitle: 'My Session', sessionId: 'session-1' }
+      await writeSession(tempDir, projectName, 'session-1', [title1, msg1, title2])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          projectName,
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          deduplicateTitles: true,
+        })
+      )
+
+      expect(result.deduplicatedRecordCount).toBe(1)
+      const remaining = await readSession(tempDir, projectName, 'session-1')
+      expect(remaining).toHaveLength(2) // msg1, title2
+      expect(remaining.filter((r: { type: string }) => r.type === 'custom-title')).toHaveLength(1)
+    })
+
+    it('should handle both agent-name and custom-title duplicates', async () => {
+      const agentName1 = { type: 'agent-name', agentName: 'Agent', sessionId: 'session-1' }
+      const title1 = { type: 'custom-title', customTitle: 'Title', sessionId: 'session-1' }
+      const msg1 = makeMessage({ uuid: 'msg-1' })
+      const compact = {
+        type: 'system',
+        subtype: 'compact_boundary',
+        uuid: 'compact-1',
+        timestamp: new Date().toISOString(),
+      }
+      const agentName2 = { type: 'agent-name', agentName: 'Agent', sessionId: 'session-1' }
+      const title2 = { type: 'custom-title', customTitle: 'Title', sessionId: 'session-1' }
+      const msg2 = makeMessage({ uuid: 'msg-2', parentUuid: 'compact-1' })
+      await writeSession(tempDir, projectName, 'session-1', [
+        agentName1,
+        title1,
+        msg1,
+        compact,
+        agentName2,
+        title2,
+        msg2,
+      ])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          projectName,
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          deduplicateTitles: true,
+        })
+      )
+
+      expect(result.deduplicatedRecordCount).toBe(2) // removed agentName1 + title1
+      const remaining = await readSession(tempDir, projectName, 'session-1')
+      expect(remaining).toHaveLength(5) // msg1, compact, agentName2, title2, msg2
+    })
+
+    it('should not modify file when no duplicates exist', async () => {
+      const agentName = { type: 'agent-name', agentName: 'Agent', sessionId: 'session-1' }
+      const msg1 = makeMessage({ uuid: 'msg-1' })
+      await writeSession(tempDir, projectName, 'session-1', [agentName, msg1])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          projectName,
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          deduplicateTitles: true,
+        })
+      )
+
+      expect(result.deduplicatedRecordCount).toBe(0)
+      const remaining = await readSession(tempDir, projectName, 'session-1')
+      expect(remaining).toHaveLength(2)
+    })
+
+    it('should keep last when values differ across duplicates', async () => {
+      const title1 = { type: 'custom-title', customTitle: 'Old Title', sessionId: 'session-1' }
+      const msg1 = makeMessage({ uuid: 'msg-1' })
+      const title2 = { type: 'custom-title', customTitle: 'New Title', sessionId: 'session-1' }
+      await writeSession(tempDir, projectName, 'session-1', [title1, msg1, title2])
+
+      await Effect.runPromise(
+        clearSessions({
+          projectName,
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          deduplicateTitles: true,
+        })
+      )
+
+      const remaining = await readSession(tempDir, projectName, 'session-1')
+      expect(remaining).toHaveLength(2) // msg1, title2
+      const titles = remaining.filter((r: { type: string }) => r.type === 'custom-title')
+      expect(titles).toHaveLength(1)
+      expect(titles[0].customTitle).toBe('New Title')
+    })
+
+    it('should be disabled by default', async () => {
+      const title1 = { type: 'custom-title', customTitle: 'Title', sessionId: 'session-1' }
+      const msg1 = makeMessage({ uuid: 'msg-1' })
+      const title2 = { type: 'custom-title', customTitle: 'Title', sessionId: 'session-1' }
+      await writeSession(tempDir, projectName, 'session-1', [title1, msg1, title2])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          projectName,
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+        })
+      )
+
+      expect(result.deduplicatedRecordCount).toBe(0)
+      const remaining = await readSession(tempDir, projectName, 'session-1')
+      expect(remaining).toHaveLength(3) // all preserved
+    })
+  })
+
+  describe('deduplicateTitleRecords standalone', () => {
+    it('should deduplicate a single session file', async () => {
+      const title1 = { type: 'custom-title', customTitle: 'Title', sessionId: 'session-1' }
+      const msg1 = makeMessage({ uuid: 'msg-1' })
+      const title2 = { type: 'custom-title', customTitle: 'Title', sessionId: 'session-1' }
+      await writeSession(tempDir, projectName, 'session-1', [title1, msg1, title2])
+
+      const result = await Effect.runPromise(deduplicateTitleRecords(projectName, 'session-1'))
+
+      expect(result.removedCount).toBe(1)
+      const remaining = await readSession(tempDir, projectName, 'session-1')
+      expect(remaining).toHaveLength(2)
     })
   })
 

--- a/packages/core/src/session/cleanup.ts
+++ b/packages/core/src/session/cleanup.ts
@@ -133,6 +133,64 @@ export const previewCleanup = (projectName?: string) =>
     return results
   })
 
+// Regex to extract "type" field from JSONL line without full parse
+const TITLE_TYPE_RE = /^{"type":"(agent-name|custom-title)"/
+
+/** Remove duplicate agent-name and custom-title records, keeping only the last of each type */
+export const deduplicateTitleRecords = (projectName: string, sessionId: string) =>
+  Effect.gen(function* () {
+    const filePath = path.join(getSessionsDir(), projectName, `${sessionId}.jsonl`)
+    const content = yield* Effect.tryPromise({
+      try: () => fs.readFile(filePath, 'utf-8'),
+      catch: (error) => new FileReadError({ filePath, cause: error }),
+    })
+    const lines = content.trim().split('\n').filter(Boolean)
+
+    if (lines.length === 0) return { removedCount: 0 }
+
+    // Find last index for each title type
+    let lastAgentNameIdx = -1
+    let lastCustomTitleIdx = -1
+    let agentNameCount = 0
+    let customTitleCount = 0
+
+    for (let i = 0; i < lines.length; i++) {
+      const match = TITLE_TYPE_RE.exec(lines[i])
+      if (!match) continue
+      if (match[1] === 'agent-name') {
+        lastAgentNameIdx = i
+        agentNameCount++
+      } else if (match[1] === 'custom-title') {
+        lastCustomTitleIdx = i
+        customTitleCount++
+      }
+    }
+
+    // Only duplicates if count > 1 for either type
+    const agentNameDuplicates = agentNameCount > 1 ? agentNameCount - 1 : 0
+    const customTitleDuplicates = customTitleCount > 1 ? customTitleCount - 1 : 0
+    const totalDuplicates = agentNameDuplicates + customTitleDuplicates
+
+    if (totalDuplicates === 0) return { removedCount: 0 }
+
+    // Build filtered lines — remove all but the last of each type
+    const filtered = lines.filter((line, idx) => {
+      const match = TITLE_TYPE_RE.exec(line)
+      if (!match) return true
+      if (match[1] === 'agent-name' && idx !== lastAgentNameIdx) return false
+      if (match[1] === 'custom-title' && idx !== lastCustomTitleIdx) return false
+      return true
+    })
+
+    const newContent = filtered.join('\n') + '\n'
+    yield* Effect.tryPromise({
+      try: () => fs.writeFile(filePath, newContent, 'utf-8'),
+      catch: (error) => new FileWriteError({ filePath, cause: error }),
+    })
+
+    return { removedCount: totalDuplicates }
+  })
+
 // Clear sessions
 export const clearSessions = (options: {
   projectName?: string
@@ -141,6 +199,7 @@ export const clearSessions = (options: {
   skipWithTodos?: boolean
   clearOrphanAgents?: boolean
   clearOrphanTodos?: boolean
+  deduplicateTitles?: boolean
 }) =>
   Effect.gen(function* () {
     const {
@@ -150,12 +209,14 @@ export const clearSessions = (options: {
       skipWithTodos = true,
       clearOrphanAgents = true,
       clearOrphanTodos = false,
+      deduplicateTitles = false,
     } = options
     const projects = yield* listProjects
     const targetProjects = projectName ? projects.filter((p) => p.name === projectName) : projects
 
     let deletedSessionCount = 0
     let removedMessageCount = 0
+    let deduplicatedRecordCount = 0
     let deletedOrphanAgentCount = 0
     let deletedOrphanTodoCount = 0
     const sessionsToDelete: { project: string; sessionId: string }[] = []
@@ -223,11 +284,30 @@ export const clearSessions = (options: {
       deletedOrphanTodoCount = result.deletedCount
     }
 
+    // Step 6: Deduplicate title records (agent-name, custom-title) if requested
+    if (deduplicateTitles) {
+      for (const project of targetProjects) {
+        const projectPath = path.join(getSessionsDir(), project.name)
+        const files = yield* Effect.tryPromise(() => fs.readdir(projectPath))
+        const sessionFiles = files.filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'))
+
+        for (const file of sessionFiles) {
+          const sessionId = file.replace('.jsonl', '')
+          // Skip sessions marked for deletion
+          if (sessionsToDelete.some((s) => s.project === project.name && s.sessionId === sessionId))
+            continue
+          const result = yield* deduplicateTitleRecords(project.name, sessionId)
+          deduplicatedRecordCount += result.removedCount
+        }
+      }
+    }
+
     return {
       success: true,
+      deduplicatedRecordCount,
       deletedCount: deletedSessionCount,
-      removedMessageCount,
       deletedOrphanAgentCount,
       deletedOrphanTodoCount,
+      removedMessageCount,
     } satisfies ClearSessionsResult
   })

--- a/packages/core/src/session/cleanup.ts
+++ b/packages/core/src/session/cleanup.ts
@@ -11,6 +11,7 @@ import { sessionHasTodos, findOrphanTodos, deleteOrphanTodos } from '../todos.js
 import { listProjects } from './projects.js'
 import { listSessions, deleteSession } from './crud.js'
 import { listSessionsMeta } from './crud-streaming.js'
+import { filterSessionFiles } from './crud-helpers.js'
 import type { Message, CleanupPreview, ClearSessionsResult } from '../types.js'
 
 // Remove invalid API key messages from a session, returns remaining message count
@@ -226,7 +227,7 @@ export const clearSessions = (options: {
       for (const project of targetProjects) {
         const projectPath = path.join(getSessionsDir(), project.name)
         const files = yield* Effect.tryPromise(() => fs.readdir(projectPath))
-        const sessionFiles = files.filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'))
+        const sessionFiles = filterSessionFiles(files)
 
         for (const file of sessionFiles) {
           const sessionId = file.replace('.jsonl', '')
@@ -289,7 +290,7 @@ export const clearSessions = (options: {
       for (const project of targetProjects) {
         const projectPath = path.join(getSessionsDir(), project.name)
         const files = yield* Effect.tryPromise(() => fs.readdir(projectPath))
-        const sessionFiles = files.filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'))
+        const sessionFiles = filterSessionFiles(files)
 
         for (const file of sessionFiles) {
           const sessionId = file.replace('.jsonl', '')

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -241,11 +241,12 @@ export interface MoveSessionResult {
 /** Result of clearing empty/invalid sessions */
 export interface ClearSessionsResult {
   success: boolean
+  deduplicatedRecordCount?: number
   deletedCount: number
-  removedMessageCount?: number
   deletedOrphanAgentCount?: number
   deletedOrphanTodoCount?: number
   deletedStaleProjectCount?: number
+  removedMessageCount?: number
 }
 
 /** Preview of sessions that would be cleaned up */


### PR DESCRIPTION
## Summary
- Add `deduplicateTitleRecords` function to remove duplicate `agent-name` and `custom-title` JSONL records that accumulate after session compaction
- Integrate as optional `deduplicateTitles` step in `clearSessions` (default: off)
- Add `deduplicatedRecordCount` field to `ClearSessionsResult` type

Closes #113

## Test plan
- [x] `pnpm -F core test` — 338 tests passing (including 7 new deduplication tests)
- [x] CI: ubuntu + windows + e2e checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
