### PR TITLE
feat(web): replace hand-rolled CLI parser with Commander.js

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -119,6 +119,10 @@ async function ensureWebServer({
   let spawnCmd: string
   let spawnArgs: string[]
 
+  // SvelteKit adapter-node only reads PORT env var, not --port CLI arg.
+  // Always set PORT in spawn env to ensure it works regardless of entry point.
+  const spawnEnv = { ...process.env, PORT: String(port) }
+
   if (webServerPath) {
     spawnCmd = 'node'
     spawnArgs = [webServerPath, '--port', String(port)]
@@ -135,6 +139,7 @@ async function ensureWebServer({
 
   return new Promise((resolve, reject) => {
     const child = spawn(spawnCmd, spawnArgs, {
+      env: spawnEnv,
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: true,
       detached: process.platform !== 'win32',

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@claude-sessions/core": "workspace:^",
     "@floating-ui/dom": "^1.7.6",
+    "commander": "^14.0.3",
     "effect": "^3.21.1",
     "marked": "^17.0.6"
   },

--- a/packages/web/src/cli.ts
+++ b/packages/web/src/cli.ts
@@ -1,58 +1,57 @@
 #!/usr/bin/env node
-/**
- * CLI entry point for @claude-sessions/web
- * Runs the SvelteKit server with configurable port
- *
- * Options:
- *   --port <number>    Port to run the server on (default: 5173)
- *   --editor <cmd>     Editor command to open files (default: code)
- *   --home <path>      Home directory for ~ expansion (default: system homedir)
- *   --project <name>   Current project name for priority sorting (default: auto-detect from cwd)
- */
+import { Command, InvalidArgumentError } from 'commander'
 import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const serverPath = path.join(__dirname, '..', 'build', 'index.js')
 
-// Parse command line arguments
-const args = process.argv.slice(2)
-let port = 5173
-let editor = ''
-let home = ''
-let project = ''
+const require = createRequire(import.meta.url)
+const { version } = require('../package.json') as { version: string }
 
-for (let i = 0; i < args.length; i++) {
-  if (args[i] === '--port' && args[i + 1]) {
-    port = parseInt(args[i + 1], 10)
-    i++
-  } else if (args[i] === '--editor' && args[i + 1]) {
-    editor = args[i + 1]
-    i++
-  } else if (args[i] === '--home' && args[i + 1]) {
-    home = args[i + 1]
-    i++
-  } else if (args[i] === '--project' && args[i + 1]) {
-    project = args[i + 1]
-    i++
+function parsePort(value: string): number {
+  const port = Number.parseInt(value, 10)
+  if (Number.isNaN(port) || port < 1 || port > 65535) {
+    throw new InvalidArgumentError('Port must be a number between 1 and 65535.')
   }
+  return port
 }
+
+const program = new Command()
+  .name('claude-sessions-web')
+  .description('Web UI for Claude Code session management')
+  .version(version)
+  .option('-p, --port <number>', 'port to run the server on', parsePort, 5173)
+  .option('--editor <cmd>', 'editor command to open files')
+  .option('--home <path>', 'home directory for ~ expansion')
+  .option('--project <name>', 'current project name for priority sorting')
+  .option('--yolo', 'skip all safety checks')
+  .parse()
+
+const opts = program.opts<{
+  port: number
+  editor?: string
+  home?: string
+  project?: string
+  yolo?: boolean
+}>()
 
 // Build environment variables
 const serverEnv: Record<string, string> = {
   ...process.env,
-  PORT: String(port),
+  PORT: String(opts.port),
 } as Record<string, string>
 
-if (editor) {
-  serverEnv.CLAUDE_SESSIONS_EDITOR = editor
+if (opts.editor) {
+  serverEnv.CLAUDE_SESSIONS_EDITOR = opts.editor
 }
-if (home) {
-  serverEnv.CLAUDE_SESSIONS_HOME = home
+if (opts.home) {
+  serverEnv.CLAUDE_SESSIONS_HOME = opts.home
 }
-if (project) {
-  serverEnv.CLAUDE_SESSIONS_PROJECT = project
+if (opts.project) {
+  serverEnv.CLAUDE_SESSIONS_PROJECT = opts.project
 }
 
 // Start the server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@floating-ui/dom':
         specifier: ^1.7.6
         version: 1.7.6
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
       effect:
         specifier: ^3.21.1
         version: 3.21.1


### PR DESCRIPTION
## Summary

- Replace hand-rolled argument parser in `packages/web/src/cli.ts` with **Commander.js** for proper `--help`, `--version`, and input validation
- Fix `ensureWebServer` in vscode-extension to pass `PORT` env var to the spawned process, resolving the production push failure where SvelteKit adapter-node ignored `--port` CLI args
- Add `--yolo` flag (accepted, no-op for now — future safety-check bypass)

Relates to #117

## Test plan

- [x] `npx @claude-sessions/web --help` prints usage info with options
- [x] `npx @claude-sessions/web --version` prints version
- [x] `npx @claude-sessions/web --port 3000` starts server on port 3000 (PORT env var set)
- [x] vscode-extension `ensureWebServer` spawns with PORT env var
- [x] MCP server continues to work (no breaking changes to cli.ts exports)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed port configuration handling to ensure the web server correctly reads the configured port.

* **New Features**
  * Added port validation to CLI (rejects invalid port numbers outside 1–65535).
  * Added `--yolo` flag to CLI options.
  * Improved `--version` flag to display package version correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->