### PR TITLE
fix(core): use latest custom-title and remove summary fallback

### DIFF
--- a/packages/core/src/__tests__/list.test.ts
+++ b/packages/core/src/__tests__/list.test.ts
@@ -33,7 +33,7 @@ describe('listSessions - should include currentSummary and customTitle', () => {
     vi.clearAllMocks()
   })
 
-  it('should return currentSummary from the first summary message', async () => {
+  it('should not extract currentSummary from in-file summary records', async () => {
     const sessionId = 'session-with-summary'
 
     const messages = [
@@ -67,7 +67,8 @@ describe('listSessions - should include currentSummary and customTitle', () => {
 
     expect(sessions).toHaveLength(1)
     expect(sessions[0].id).toBe(sessionId)
-    expect(sessions[0].currentSummary).toBe('This is the current summary text')
+    // In-file summary records are no longer extracted as currentSummary
+    expect(sessions[0].currentSummary).toBeUndefined()
     expect(sessions[0].title).toBe('Hello world')
   })
 
@@ -99,7 +100,7 @@ describe('listSessions - should include currentSummary and customTitle', () => {
     expect(sessions[0].title).toBe('Original first message')
   })
 
-  it('should return both currentSummary and customTitle when both exist', async () => {
+  it('should ignore in-file summary when customTitle exists', async () => {
     const sessionId = 'session-with-both'
 
     const messages = [
@@ -130,7 +131,8 @@ describe('listSessions - should include currentSummary and customTitle', () => {
 
     expect(sessions).toHaveLength(1)
     expect(sessions[0].customTitle).toBe('Custom Title Here')
-    expect(sessions[0].currentSummary).toBe('Summary text here')
+    // In-file summary records are no longer extracted
+    expect(sessions[0].currentSummary).toBeUndefined()
     expect(sessions[0].title).toBe('First user message')
   })
 

--- a/packages/core/src/session/backup.test.ts
+++ b/packages/core/src/session/backup.test.ts
@@ -106,16 +106,30 @@ describe('listBackupSessions', () => {
     expect(result[0].title).toBe('My Custom Title')
   })
 
-  it('falls back to summary when no custom-title exists', async () => {
+  it('uses the latest custom-title when multiple exist', async () => {
+    await fs.mkdir(path.join(tmpDir, '.bak'), { recursive: true })
+    const messages = [
+      { type: 'custom-title', customTitle: 'Old Title' },
+      makeMessage(),
+      { type: 'custom-title', customTitle: 'Latest Title' },
+    ]
+    await writeBackup(tmpDir, 'project-a', 'session-multi', messages)
+
+    const result = await Effect.runPromise(listBackupSessions())
+    expect(result[0].title).toBe('Latest Title')
+  })
+
+  it('ignores summary records for title extraction', async () => {
     await fs.mkdir(path.join(tmpDir, '.bak'), { recursive: true })
     const messages = [makeMessage(), { type: 'summary', summary: 'Session about testing' }]
     await writeBackup(tmpDir, 'project-a', 'session-sum', messages)
 
     const result = await Effect.runPromise(listBackupSessions())
-    expect(result[0].title).toBe('Session about testing')
+    // Summary is no longer used as title fallback — falls through to first user message or Untitled
+    expect(result[0].title).toBe('Untitled')
   })
 
-  it('falls back to first user message text when no title or summary', async () => {
+  it('falls back to first user message text when no custom-title', async () => {
     await fs.mkdir(path.join(tmpDir, '.bak'), { recursive: true })
     const messages = [
       {

--- a/packages/core/src/session/backup.ts
+++ b/packages/core/src/session/backup.ts
@@ -25,19 +25,16 @@ const parseBackupFilename = (
   }
 }
 
-/** Extract title from backup file with tiered fallback: customTitle → summary → first user message */
+/** Extract title from backup file with tiered fallback: customTitle → first user message */
 const extractBackupTitle = (lines: string[]): string => {
-  let latestSummary: string | undefined
+  let latestCustomTitle: string | undefined
   let firstUserMessage: string | undefined
 
   for (const line of lines) {
     try {
       const parsed = JSON.parse(line) as Record<string, unknown>
       if (parsed.type === 'custom-title' && typeof parsed.customTitle === 'string') {
-        return parsed.customTitle
-      }
-      if (parsed.type === 'summary' && typeof parsed.summary === 'string') {
-        latestSummary = parsed.summary
+        latestCustomTitle = parsed.customTitle
       }
       if (
         parsed.type === 'user' &&
@@ -50,7 +47,7 @@ const extractBackupTitle = (lines: string[]): string => {
       // skip invalid lines
     }
   }
-  return latestSummary ?? firstUserMessage ?? 'Untitled'
+  return latestCustomTitle ?? firstUserMessage ?? 'Untitled'
 }
 
 /** List all backed-up sessions from the .bak directory */

--- a/packages/core/src/session/crud-streaming.ts
+++ b/packages/core/src/session/crud-streaming.ts
@@ -31,7 +31,6 @@ const scanSessionMeta = async (
   let title: string | undefined
   let agentName: string | undefined
   let customTitle: string | undefined
-  let currentSummary: string | undefined
   let firstTimestamp: string | undefined
   let lastTimestamp: string | undefined
 
@@ -65,12 +64,6 @@ const scanSessionMeta = async (
       }
     } else if (type === 'summary' && !hasSummary) {
       hasSummary = true
-      try {
-        const msg = JSON.parse(line) as Message
-        currentSummary = msg.summary as string
-      } catch {
-        /* skip malformed */
-      }
     } else if (type === 'custom-title') {
       try {
         const msg = JSON.parse(line) as { customTitle?: string }
@@ -92,7 +85,6 @@ const scanSessionMeta = async (
     title,
     agentName,
     customTitle,
-    currentSummary,
     userAssistantCount,
     hasSummary,
     firstTimestamp,

--- a/packages/core/src/session/crud.ts
+++ b/packages/core/src/session/crud.ts
@@ -78,13 +78,6 @@ const readSessionMeta = (projectPath: string, file: string, projectName: string)
       O.getOrUndefined
     )
 
-    const currentSummary = pipe(
-      messages,
-      A.findFirst((m) => m.type === 'summary'),
-      O.map((m) => m.summary as string),
-      O.getOrUndefined
-    )
-
     // Only titles after the last user/assistant message count as current
     let customTitle: string | undefined
     let agentName: string | undefined
@@ -102,7 +95,6 @@ const readSessionMeta = (projectPath: string, file: string, projectName: string)
       title,
       agentName,
       customTitle,
-      currentSummary,
       userAssistantCount: userAssistantMessages.length,
       hasSummary,
       firstTimestamp: userAssistantMessages[0]?.timestamp,

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -138,6 +138,7 @@ async function ensureWebServer({
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: true,
       detached: process.platform !== 'win32',
+      env: { ...process.env, PORT: String(port) },
     })
 
     webServerProcess = child

--- a/packages/vscode-extension/src/test/runTest.ts
+++ b/packages/vscode-extension/src/test/runTest.ts
@@ -9,8 +9,8 @@ async function main() {
   const extensionDevelopmentPath = path.resolve(__dirname, '../../')
   const extensionTestsPath = path.resolve(__dirname, './suite/index')
 
-  // Use short temp path for user data to avoid IPC path length issues
-  const userDataDir = path.join(os.tmpdir(), 'vscode-test-sessions')
+  // Use unique temp path per run to avoid lock conflicts with running VSCode instances
+  const userDataDir = path.join(os.tmpdir(), `vscode-test-sessions-${Date.now()}`)
 
   console.log('Extension path:', extensionDevelopmentPath)
   console.log('Tests path:', extensionTestsPath)


### PR DESCRIPTION
## Summary

- `extractBackupTitle` now collects all `custom-title` records and uses the latest one instead of returning on the first match (fixes incorrect display when a session is renamed multiple times)
- Remove `currentSummary` extraction from in-file `summary` records in `readSessionMeta` and `scanSessionMeta` (no longer generated since Claude Code v2.1.11)
- Keep `currentSummary` in types and tree building for cross-session summaries

**Note**: This branch also contains commit 55e0dba (PORT env + test isolation) which overlaps with PR #120. When PR #120 merges first, the `extension.ts` conflict should be resolved by taking PR #120's version.

Relates to #118

## Test plan

- [x] `pnpm -F core test` — all tests pass (377 tests, including updated backup.test.ts and list.test.ts)
- [x] Backup listing shows latest rename title (not first)
- [x] Session listing no longer uses in-file summary as display title
