### PR TITLE
feat: add find session by ID with partial matching

### DIFF
--- a/packages/core/src/__tests__/search.test.ts
+++ b/packages/core/src/__tests__/search.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { Effect } from 'effect'
+
+// Mock the paths module to use temp directory
+vi.mock('../paths.js', async () => {
+  const actual = await vi.importActual('../paths.js')
+  return {
+    ...actual,
+    getSessionsDir: vi.fn(),
+  }
+})
+
+import { searchBySessionId, searchSessions } from '../session/search.js'
+import { getSessionsDir } from '../paths.js'
+
+describe('searchBySessionId', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-search-test-'))
+
+    // Create two projects with sessions
+    const project1Dir = path.join(tempDir, '-Users-test-project')
+    const project2Dir = path.join(tempDir, '-Users-test-other')
+    await fs.mkdir(project1Dir, { recursive: true })
+    await fs.mkdir(project2Dir, { recursive: true })
+
+    // Project 1: two sessions
+    await fs.writeFile(
+      path.join(project1Dir, 'a1b2c3d4-e5f6-7890-abcd-ef1234567890.jsonl'),
+      '{"type":"user","uuid":"msg-1","message":{"role":"user","content":"Hello world"},"timestamp":"2026-04-20T10:00:00Z"}\n'
+    )
+    await fs.writeFile(
+      path.join(project1Dir, 'a1b2c3d4-ffff-0000-1111-222233334444.jsonl'),
+      '{"type":"user","uuid":"msg-2","message":{"role":"user","content":"Second session"},"timestamp":"2026-04-21T10:00:00Z"}\n'
+    )
+    // Agent file (should be excluded)
+    await fs.writeFile(path.join(project1Dir, 'agent-task.jsonl'), '{"type":"user"}\n')
+
+    // Project 2: one session with overlapping prefix
+    await fs.writeFile(
+      path.join(project2Dir, 'a1b2c3d4-9999-8888-7777-666655554444.jsonl'),
+      '{"type":"user","uuid":"msg-3","message":{"role":"user","content":"Cross-project session"},"timestamp":"2026-04-22T10:00:00Z"}\n'
+    )
+
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('should find session by exact ID', async () => {
+    const results = await Effect.runPromise(
+      searchBySessionId('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    )
+    expect(results).toHaveLength(1)
+    expect(results[0].sessionId).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    expect(results[0].matchType).toBe('sessionId')
+  })
+
+  it('should find sessions by partial ID prefix', async () => {
+    const results = await Effect.runPromise(searchBySessionId('a1b2c3d4'))
+    // Should match all 3 sessions across both projects
+    expect(results).toHaveLength(3)
+    expect(results.every((r) => r.matchType === 'sessionId')).toBe(true)
+  })
+
+  it('should return empty array for non-existent ID', async () => {
+    const results = await Effect.runPromise(searchBySessionId('deadbeef-0000'))
+    expect(results).toEqual([])
+  })
+
+  it('should filter by project when projectName is specified', async () => {
+    const results = await Effect.runPromise(
+      searchBySessionId('a1b2c3d4', { projectName: '-Users-test-project' })
+    )
+    expect(results).toHaveLength(2)
+    expect(results.every((r) => r.projectName === '-Users-test-project')).toBe(true)
+  })
+
+  it('should sort results by timestamp (newest first)', async () => {
+    const results = await Effect.runPromise(searchBySessionId('a1b2c3d4'))
+    expect(results).toHaveLength(3)
+    // project2 session is newest (2026-04-22)
+    expect(results[0].projectName).toBe('-Users-test-other')
+  })
+
+  it('should include title from first user message', async () => {
+    const results = await Effect.runPromise(
+      searchBySessionId('a1b2c3d4-e5f6-7890-abcd-ef1234567890')
+    )
+    expect(results[0].title).toBeTruthy()
+  })
+
+  it('should exclude agent files', async () => {
+    const results = await Effect.runPromise(searchBySessionId('agent-task'))
+    expect(results).toEqual([])
+  })
+})
+
+describe('searchSessions - session ID detection', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-search-detect-'))
+    const projectDir = path.join(tempDir, '-Users-test-detect')
+    await fs.mkdir(projectDir, { recursive: true })
+
+    await fs.writeFile(
+      path.join(projectDir, 'abcdef12-3456-7890-abcd-ef1234567890.jsonl'),
+      '{"type":"user","uuid":"msg-1","message":{"role":"user","content":"Detectable session"},"timestamp":"2026-04-20T10:00:00Z"}\n'
+    )
+
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('should detect hex-pattern queries and return sessionId matchType', async () => {
+    const results = await Effect.runPromise(searchSessions('abcdef12'))
+    const idMatch = results.find((r) => r.matchType === 'sessionId')
+    expect(idMatch).toBeDefined()
+    expect(idMatch!.sessionId).toBe('abcdef12-3456-7890-abcd-ef1234567890')
+  })
+
+  it('should fall through to title search when no ID matches', async () => {
+    const results = await Effect.runPromise(searchSessions('deadbeef99'))
+    // No sessionId matches, title search runs (may be empty)
+    expect(Array.isArray(results)).toBe(true)
+    expect(results.every((r) => r.matchType !== 'sessionId')).toBe(true)
+  })
+
+  it('should not trigger ID search for non-hex queries', async () => {
+    // "hello world" does not match SESSION_ID_PATTERN
+    const results = await Effect.runPromise(searchSessions('hello world'))
+    expect(results.every((r) => r.matchType !== 'sessionId')).toBe(true)
+  })
+
+  it('should not trigger ID search for short queries', async () => {
+    // "abc" is too short (< 8 chars)
+    const results = await Effect.runPromise(searchSessions('abc'))
+    // Should only have title/content matches, not sessionId
+    expect(results.every((r) => r.matchType !== 'sessionId')).toBe(true)
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,6 +131,7 @@ export {
   splitSession,
   previewCleanup,
   clearSessions,
+  searchBySessionId,
   searchSessions,
   loadSessionTreeData,
   loadProjectTreeData,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -37,6 +37,7 @@ export {
   previewCleanup,
   clearSessions,
   // Search
+  searchBySessionId,
   searchSessions,
   // Files
   getSessionFiles,

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -43,7 +43,7 @@ export { listBackupSessions, restoreSession } from './backup.js'
 export { previewCleanup, clearSessions } from './cleanup.js'
 
 // Search
-export { searchSessions } from './search.js'
+export { searchBySessionId, searchSessions } from './search.js'
 
 // File tracking
 export { getSessionFiles } from './files.js'

--- a/packages/core/src/session/search.ts
+++ b/packages/core/src/session/search.ts
@@ -92,6 +92,69 @@ const searchProjectContent = (project: Project, queryLower: string, alreadyFound
     return results.filter((r): r is NonNullable<typeof r> => r !== null)
   })
 
+// Pattern to detect potential session ID queries (hex chars and hyphens, 8+ chars)
+const SESSION_ID_PATTERN = /^[a-f0-9][a-f0-9-]{7,}$/i
+
+// Search sessions by partial session ID (file name prefix matching)
+export const searchBySessionId = (partialId: string, options: { projectName?: string } = {}) =>
+  Effect.gen(function* () {
+    const partialIdLower = partialId.toLowerCase()
+    const projects = yield* listProjects
+    const targetProjects = options.projectName
+      ? projects.filter((p) => p.name === options.projectName)
+      : projects
+
+    const scanEffects = targetProjects.map((project) =>
+      pipe(
+        Effect.tryPromise(() => fs.readdir(path.join(getSessionsDir(), project.name))),
+        Effect.map((files) =>
+          files
+            .filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'))
+            .map((f) => f.replace('.jsonl', ''))
+            .filter((id) => id.toLowerCase().startsWith(partialIdLower))
+            .map((sessionId) => ({ sessionId, projectName: project.name }))
+        ),
+        Effect.catchAll(() => Effect.succeed([] as { sessionId: string; projectName: string }[]))
+      )
+    )
+
+    const matchesNested = yield* Effect.all(scanEffects, { concurrency: 10 })
+    const matches = matchesNested.flat()
+
+    // Resolve titles for matched sessions
+    const resultEffects = matches.map(({ sessionId, projectName }) =>
+      pipe(
+        listSessions(projectName),
+        Effect.map((sessions) => {
+          const session = sessions.find((s) => s.id === sessionId)
+          return {
+            sessionId,
+            projectName,
+            title: session?.title ?? session?.customTitle ?? `Session ${sessionId.slice(0, 8)}`,
+            matchType: 'sessionId' as const,
+            timestamp: session?.updatedAt,
+          } satisfies SearchResult
+        }),
+        Effect.catchAll(() =>
+          Effect.succeed({
+            sessionId,
+            projectName,
+            title: `Session ${sessionId.slice(0, 8)}`,
+            matchType: 'sessionId' as const,
+            timestamp: undefined,
+          } satisfies SearchResult)
+        )
+      )
+    )
+
+    const results = yield* Effect.all(resultEffects, { concurrency: 10 })
+    return results.sort((a, b) => {
+      const dateA = a.timestamp ? new Date(a.timestamp).getTime() : 0
+      const dateB = b.timestamp ? new Date(b.timestamp).getTime() : 0
+      return dateB - dateA
+    })
+  })
+
 // Search sessions - two-phase: title search (fast) then content search (slow)
 export const searchSessions = (
   query: string,
@@ -100,6 +163,14 @@ export const searchSessions = (
   Effect.gen(function* () {
     const { projectName, searchContent = false } = options
     const queryLower = query.toLowerCase()
+
+    // Phase 0: Session ID detection — if query looks like a session ID, search by ID first
+    if (SESSION_ID_PATTERN.test(query)) {
+      const idResults = yield* searchBySessionId(query, { projectName })
+      if (idResults.length > 0) {
+        return idResults
+      }
+    }
 
     const projects = yield* listProjects
     const targetProjects = projectName ? projects.filter((p) => p.name === projectName) : projects

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -295,7 +295,7 @@ export interface SearchResult {
   sessionId: string
   projectName: string
   title: string
-  matchType: 'title' | 'content'
+  matchType: 'title' | 'content' | 'sessionId'
   snippet?: string
   messageUuid?: string
   timestamp?: string

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -254,7 +254,7 @@ export interface SearchResult {
   sessionId: string
   projectName: string
   title: string
-  matchType: 'title' | 'content'
+  matchType: 'title' | 'content' | 'sessionId'
   snippet?: string
   messageUuid?: string
   timestamp?: string

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -240,6 +240,13 @@
         project: sessionInfo?.projectName,
       })
       searchResults = sortResultsWithCurrentSession(titleResults)
+
+      // Auto-navigate when exactly one session ID match is found
+      const idMatches = titleResults.filter((r) => r.matchType === 'sessionId')
+      if (idMatches.length === 1) {
+        selectSearchResult(idMatches[0])
+        return
+      }
     } catch (e) {
       console.error('Title search error:', e)
     } finally {
@@ -416,18 +423,28 @@
               >
                 <div class="flex items-center gap-2">
                   <span
-                    class="text-xs px-1.5 py-0.5 rounded {result.matchType === 'title'
-                      ? 'bg-gh-green/20 text-gh-green'
-                      : 'bg-gh-accent/20 text-gh-accent'}"
+                    class="text-xs px-1.5 py-0.5 rounded {result.matchType === 'sessionId'
+                      ? 'bg-gh-accent/20 text-gh-accent font-mono'
+                      : result.matchType === 'title'
+                        ? 'bg-gh-green/20 text-gh-green'
+                        : 'bg-gh-accent/20 text-gh-accent'}"
                   >
-                    {result.matchType === 'title' ? 'Title' : 'Content'}
+                    {result.matchType === 'sessionId'
+                      ? 'ID'
+                      : result.matchType === 'title'
+                        ? 'Title'
+                        : 'Content'}
                   </span>
                   <span class="text-xs text-gh-text-secondary truncate flex-shrink-0 max-w-[120px]"
                     >{formatProjectPath(result.projectName)}</span
                   >
                   <span class="text-sm font-medium truncate">{result.title}</span>
                 </div>
-                {#if result.snippet}
+                {#if result.matchType === 'sessionId'}
+                  <div class="text-xs text-gh-text-secondary mt-1 font-mono truncate">
+                    {result.sessionId}
+                  </div>
+                {:else if result.snippet}
                   <div class="text-xs text-gh-text-secondary mt-1 line-clamp-2">
                     {result.snippet}
                   </div>


### PR DESCRIPTION
## Summary

Add session ID search capability to the existing search system. Users can now search by full or partial session ID (UUID) to directly navigate to a specific session.

**Core changes:**
- New `searchBySessionId(partialId)` function that scans session filenames across all projects using prefix matching
- `searchSessions()` now auto-detects UUID-like queries (hex + hyphens, 8+ chars) and runs ID search first before falling back to title/content search
- `SearchResult.matchType` extended with `'sessionId'` variant

**Web changes:**
- Search dropdown displays `ID` badge (mono font) for session ID matches with the full session ID shown below the title
- Auto-navigates when exactly one session ID match is found (skip dropdown)

Relates to #130

## Test plan

- [x] `pnpm -F core test` passes (11 new search tests: exact match, partial prefix, cross-project, empty, project filter, sort order, agent exclusion, ID detection, fallthrough, non-hex, short query)
- [x] Search by pasting full session UUID navigates directly to session
- [x] Search by first 8 chars of session ID shows matching sessions with ID badge
- [x] Non-UUID search queries (regular text) still work as before (title + content search)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session ID search: Find sessions by their ID with partial matching across projects, including optional project filtering
  * Enhanced results display: Search results now show session ID matches with a distinctive "ID" badge and monospace styling
  * Auto-selection: Single session ID matches are automatically selected, streamlining the search workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->