### PR TITLE
feat(vscode): apply defaultTerminalMode to openTerminalHere command

### DIFF
--- a/packages/core/src/__tests__/resume.test.ts
+++ b/packages/core/src/__tests__/resume.test.ts
@@ -1,45 +1,172 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { spawn, type ChildProcess } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
 
+// Mock child_process before importing the module under test
 vi.mock('node:child_process', () => ({
+  execSync: vi.fn(),
   spawn: vi.fn(),
 }))
 
+import { execSync, spawn } from 'node:child_process'
+import { startClaude, openExternalTerminal } from '../resume.js'
+
+const mockExecSync = vi.mocked(execSync)
 const mockSpawn = vi.mocked(spawn)
 
-// Create a minimal mock ChildProcess
-const createMockChild = (pid = 12345): Partial<ChildProcess> => ({
-  pid,
-  unref: vi.fn(),
-})
+function createMockChild(pid = 1234): ChildProcess {
+  return { pid, unref: vi.fn() } as unknown as ChildProcess
+}
 
-describe('openExternalTerminal', () => {
-  let originalPlatform: PropertyDescriptor | undefined
+const setPlatform = (platform: string) => {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+describe('startClaude', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
 
   beforeEach(() => {
     vi.resetAllMocks()
-    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    mockSpawn.mockReturnValue(createMockChild())
   })
 
   afterEach(() => {
-    if (originalPlatform) {
-      Object.defineProperty(process, 'platform', originalPlatform)
-    }
+    Object.defineProperty(process, 'platform', originalPlatform)
   })
 
-  const setPlatform = (platform: string) => {
-    Object.defineProperty(process, 'platform', { value: platform, configurable: true })
-  }
-
-  it('should open Terminal.app via osascript on macOS', async () => {
+  it('should spawn osascript on macOS with command and cwd', () => {
     setPlatform('darwin')
-    mockSpawn.mockReturnValue(createMockChild(100) as ChildProcess)
 
-    const { openExternalTerminal } = await import('../resume.js')
+    const result = startClaude({ command: 'claude --resume abc', cwd: '/test' })
+
+    expect(result.success).toBe(true)
+    const scriptArg = mockSpawn.mock.calls[0][1]![1] as string
+    expect(scriptArg).toContain('claude --resume abc')
+    expect(scriptArg).toContain('/test')
+  })
+
+  it('should open cmd on Windows', () => {
+    setPlatform('win32')
+
+    const result = startClaude({ command: 'claude --resume abc', cwd: 'C:\\Users\\test' })
+
+    expect(result.success).toBe(true)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'cmd',
+      ['/c', 'start', 'cmd', '/k', 'claude --resume abc'],
+      expect.objectContaining({ cwd: 'C:\\Users\\test', detached: true })
+    )
+  })
+})
+
+describe('startClaude - Linux terminal fallback', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    setPlatform('linux')
+    mockSpawn.mockReturnValue(createMockChild())
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('should use --working-directory for gnome-terminal', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('/usr/bin/gnome-terminal'))
+
+    const result = startClaude({ command: 'claude --resume abc', cwd: '/home/user/project' })
+
+    expect(result.success).toBe(true)
+    expect(mockExecSync).toHaveBeenCalledWith('command -v gnome-terminal', { stdio: 'ignore' })
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gnome-terminal',
+      ['--working-directory', '/home/user/project', '--', 'bash', '-c', 'claude --resume abc'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' })
+    )
+  })
+
+  it('should use --workdir for konsole when gnome-terminal is missing', () => {
+    mockExecSync
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockReturnValueOnce(Buffer.from('/usr/bin/konsole'))
+
+    const result = startClaude({ command: 'claude --resume abc', cwd: '/home/user/project' })
+
+    expect(result.success).toBe(true)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'konsole',
+      ['--workdir', '/home/user/project', '-e', 'bash', '-c', 'claude --resume abc'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' })
+    )
+  })
+
+  it('should use shell wrapper for xterm (no --workdir support)', () => {
+    mockExecSync
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockReturnValueOnce(Buffer.from('/usr/bin/xterm'))
+
+    const result = startClaude({ command: 'claude --resume abc', cwd: '/home/user/project' })
+
+    expect(result.success).toBe(true)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'xterm',
+      ['-e', 'cd "/home/user/project" && claude --resume abc; exec $SHELL'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' })
+    )
+  })
+
+  it('should return error when no terminal emulator is found', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not found')
+    })
+
+    const result = startClaude({ command: 'claude --resume abc', cwd: '/home/user/project' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('No supported terminal emulator found')
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
+  it('should skip to next terminal when command -v fails', () => {
+    mockExecSync
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockReturnValueOnce(Buffer.from('/usr/bin/konsole'))
+
+    startClaude({ command: 'claude --resume abc', cwd: '/tmp' })
+
+    expect(mockExecSync).toHaveBeenCalledTimes(2)
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+    expect(mockSpawn.mock.calls[0][0]).toBe('konsole')
+  })
+})
+
+describe('openExternalTerminal', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockSpawn.mockReturnValue(createMockChild())
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('should open Terminal.app via osascript on macOS', () => {
+    setPlatform('darwin')
+
     const result = openExternalTerminal({ cwd: '/test/project' })
 
     expect(result.success).toBe(true)
-    expect(result.pid).toBe(100)
     expect(mockSpawn).toHaveBeenCalledWith(
       'osascript',
       ['-e', expect.stringContaining('Terminal')],
@@ -47,95 +174,92 @@ describe('openExternalTerminal', () => {
     )
   })
 
-  it('should include correct cwd in macOS AppleScript', async () => {
-    setPlatform('darwin')
-    mockSpawn.mockReturnValue(createMockChild() as ChildProcess)
-
-    const { openExternalTerminal } = await import('../resume.js')
-    openExternalTerminal({ cwd: '/Users/test/my project' })
-
-    const scriptArg = mockSpawn.mock.calls[0][1]![1] as string
-    expect(scriptArg).toContain('/Users/test/my project')
-    expect(scriptArg).toContain('cd')
-  })
-
-  it('should open cmd on Windows', async () => {
+  it('should open cmd on Windows', () => {
     setPlatform('win32')
-    mockSpawn.mockReturnValue(createMockChild(200) as ChildProcess)
 
-    const { openExternalTerminal } = await import('../resume.js')
     const result = openExternalTerminal({ cwd: 'C:\\Users\\test' })
 
     expect(result.success).toBe(true)
-    expect(result.pid).toBe(200)
     expect(mockSpawn).toHaveBeenCalledWith(
       'cmd',
       ['/c', 'start', 'cmd', '/k', expect.stringContaining('C:\\Users\\test')],
       expect.objectContaining({ cwd: 'C:\\Users\\test', detached: true })
     )
   })
+})
 
-  it('should try terminal emulators on Linux', async () => {
+describe('openExternalTerminal - Linux terminal fallback', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    vi.resetAllMocks()
     setPlatform('linux')
-    mockSpawn.mockReturnValue(createMockChild(300) as ChildProcess)
+    mockSpawn.mockReturnValue(createMockChild())
+  })
 
-    const { openExternalTerminal } = await import('../resume.js')
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('should use --working-directory for gnome-terminal', () => {
+    mockExecSync.mockReturnValueOnce(Buffer.from('/usr/bin/gnome-terminal'))
+
     const result = openExternalTerminal({ cwd: '/home/user/project' })
 
     expect(result.success).toBe(true)
-    expect(result.pid).toBe(300)
-    // Should try gnome-terminal first
     expect(mockSpawn).toHaveBeenCalledWith(
       'gnome-terminal',
       ['--working-directory', '/home/user/project'],
-      { detached: true, stdio: 'ignore' }
+      expect.objectContaining({ detached: true, stdio: 'ignore' })
     )
   })
 
-  it('should return error when spawn throws', async () => {
-    setPlatform('darwin')
-    mockSpawn.mockImplementation(() => {
-      throw new Error('spawn failed')
-    })
+  it('should use --workdir for konsole', () => {
+    mockExecSync
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockReturnValueOnce(Buffer.from('/usr/bin/konsole'))
 
-    const { openExternalTerminal } = await import('../resume.js')
-    const result = openExternalTerminal({ cwd: '/test' })
+    const result = openExternalTerminal({ cwd: '/home/user/project' })
 
-    expect(result.success).toBe(false)
-    expect(result.error).toBe('spawn failed')
+    expect(result.success).toBe(true)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'konsole',
+      ['--workdir', '/home/user/project'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' })
+    )
   })
 
-  it('should return error on unsupported platform', async () => {
-    setPlatform('freebsd')
-    // Linux terminals all fail
-    mockSpawn.mockImplementation(() => {
+  it('should use shell wrapper for xterm (no --workdir support)', () => {
+    mockExecSync
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('not found')
+      })
+      .mockReturnValueOnce(Buffer.from('/usr/bin/xterm'))
+
+    const result = openExternalTerminal({ cwd: '/home/user/project' })
+
+    expect(result.success).toBe(true)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'xterm',
+      ['-e', 'cd "/home/user/project" && exec $SHELL'],
+      expect.objectContaining({ detached: true, stdio: 'ignore' })
+    )
+  })
+
+  it('should return error when no terminal is found', () => {
+    mockExecSync.mockImplementation(() => {
       throw new Error('not found')
     })
 
-    const { openExternalTerminal } = await import('../resume.js')
-    const result = openExternalTerminal({ cwd: '/test' })
+    const result = openExternalTerminal({ cwd: '/home/user/project' })
 
     expect(result.success).toBe(false)
-    expect(result.error).toContain('No supported terminal emulator found')
-  })
-})
-
-describe('startClaude', () => {
-  beforeEach(() => {
-    vi.resetAllMocks()
-  })
-
-  it('should spawn osascript on macOS with command and cwd', async () => {
-    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
-    mockSpawn.mockReturnValue(createMockChild(400) as ChildProcess)
-
-    const { startClaude } = await import('../resume.js')
-    const result = startClaude({ command: 'claude --resume abc', cwd: '/test' })
-
-    expect(result.success).toBe(true)
-    expect(result.pid).toBe(400)
-    const scriptArg = mockSpawn.mock.calls[0][1]![1] as string
-    expect(scriptArg).toContain('claude --resume abc')
-    expect(scriptArg).toContain('/test')
+    expect(result.error).toBe('No supported terminal emulator found')
+    expect(mockSpawn).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/__tests__/resume.test.ts
+++ b/packages/core/src/__tests__/resume.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { spawn, type ChildProcess } from 'node:child_process'
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}))
+
+const mockSpawn = vi.mocked(spawn)
+
+// Create a minimal mock ChildProcess
+const createMockChild = (pid = 12345): Partial<ChildProcess> => ({
+  pid,
+  unref: vi.fn(),
+})
+
+describe('openExternalTerminal', () => {
+  let originalPlatform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  })
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  const setPlatform = (platform: string) => {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+  }
+
+  it('should open Terminal.app via osascript on macOS', async () => {
+    setPlatform('darwin')
+    mockSpawn.mockReturnValue(createMockChild(100) as ChildProcess)
+
+    const { openExternalTerminal } = await import('../resume.js')
+    const result = openExternalTerminal({ cwd: '/test/project' })
+
+    expect(result.success).toBe(true)
+    expect(result.pid).toBe(100)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'osascript',
+      ['-e', expect.stringContaining('Terminal')],
+      { detached: true, stdio: 'ignore' }
+    )
+  })
+
+  it('should include correct cwd in macOS AppleScript', async () => {
+    setPlatform('darwin')
+    mockSpawn.mockReturnValue(createMockChild() as ChildProcess)
+
+    const { openExternalTerminal } = await import('../resume.js')
+    openExternalTerminal({ cwd: '/Users/test/my project' })
+
+    const scriptArg = mockSpawn.mock.calls[0][1]![1] as string
+    expect(scriptArg).toContain('/Users/test/my project')
+    expect(scriptArg).toContain('cd')
+  })
+
+  it('should open cmd on Windows', async () => {
+    setPlatform('win32')
+    mockSpawn.mockReturnValue(createMockChild(200) as ChildProcess)
+
+    const { openExternalTerminal } = await import('../resume.js')
+    const result = openExternalTerminal({ cwd: 'C:\\Users\\test' })
+
+    expect(result.success).toBe(true)
+    expect(result.pid).toBe(200)
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'cmd',
+      ['/c', 'start', 'cmd', '/k', expect.stringContaining('C:\\Users\\test')],
+      expect.objectContaining({ cwd: 'C:\\Users\\test', detached: true })
+    )
+  })
+
+  it('should try terminal emulators on Linux', async () => {
+    setPlatform('linux')
+    mockSpawn.mockReturnValue(createMockChild(300) as ChildProcess)
+
+    const { openExternalTerminal } = await import('../resume.js')
+    const result = openExternalTerminal({ cwd: '/home/user/project' })
+
+    expect(result.success).toBe(true)
+    expect(result.pid).toBe(300)
+    // Should try gnome-terminal first
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'gnome-terminal',
+      ['--working-directory', '/home/user/project'],
+      { detached: true, stdio: 'ignore' }
+    )
+  })
+
+  it('should return error when spawn throws', async () => {
+    setPlatform('darwin')
+    mockSpawn.mockImplementation(() => {
+      throw new Error('spawn failed')
+    })
+
+    const { openExternalTerminal } = await import('../resume.js')
+    const result = openExternalTerminal({ cwd: '/test' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('spawn failed')
+  })
+
+  it('should return error on unsupported platform', async () => {
+    setPlatform('freebsd')
+    // Linux terminals all fail
+    mockSpawn.mockImplementation(() => {
+      throw new Error('not found')
+    })
+
+    const { openExternalTerminal } = await import('../resume.js')
+    const result = openExternalTerminal({ cwd: '/test' })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('No supported terminal emulator found')
+  })
+})
+
+describe('startClaude', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('should spawn osascript on macOS with command and cwd', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+    mockSpawn.mockReturnValue(createMockChild(400) as ChildProcess)
+
+    const { startClaude } = await import('../resume.js')
+    const result = startClaude({ command: 'claude --resume abc', cwd: '/test' })
+
+    expect(result.success).toBe(true)
+    expect(result.pid).toBe(400)
+    const scriptArg = mockSpawn.mock.calls[0][1]![1] as string
+    expect(scriptArg).toContain('claude --resume abc')
+    expect(scriptArg).toContain('/test')
+  })
+})

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -2,7 +2,7 @@
  * Resume/start session functionality - Server-side only
  * This module uses child_process and should NOT be imported in browser environments
  */
-import { spawn } from 'node:child_process'
+import { execSync, spawn } from 'node:child_process'
 import type {
   OpenExternalTerminalOptions,
   ResumeSessionOptions,
@@ -52,19 +52,29 @@ end tell
       return { success: true, pid: child.pid }
     }
 
-    // Linux: try common terminal emulators
-    const terminals = ['gnome-terminal', 'konsole', 'xterm']
-    for (const term of terminals) {
+    // Linux: try common terminal emulators with command -v pre-check.
+    // spawn() ENOENT is async, so try/catch cannot catch missing binaries.
+    // Use execSync('command -v <term>') to verify the binary exists first.
+    const terminalConfigs: Array<{ bin: string; args: string[] }> = [
+      {
+        bin: 'gnome-terminal',
+        args: ['--working-directory', workingDir, '--', 'bash', '-c', command],
+      },
+      { bin: 'konsole', args: ['--workdir', workingDir, '-e', 'bash', '-c', command] },
+      { bin: 'xterm', args: ['-e', `cd "${workingDir}" && ${command}; exec $SHELL`] },
+    ]
+    for (const { bin, args } of terminalConfigs) {
       try {
-        const child = spawn(term, ['--', 'bash', '-c', `cd "${workingDir}" && ${command}`], {
-          detached: true,
-          stdio: 'ignore',
-        })
-        child.unref()
-        return { success: true, pid: child.pid }
+        execSync(`command -v ${bin}`, { stdio: 'ignore' })
       } catch {
         continue
       }
+      const child = spawn(bin, args, {
+        detached: true,
+        stdio: 'ignore',
+      })
+      child.unref()
+      return { success: true, pid: child.pid }
     }
 
     return { success: false, error: 'No supported terminal emulator found' }
@@ -133,20 +143,25 @@ end tell
       return { success: true, pid: child.pid }
     }
 
-    // Linux: try common terminal emulators
-    const terminals = ['gnome-terminal', 'konsole', 'xterm']
-    for (const term of terminals) {
+    // Linux: try common terminal emulators with command -v pre-check.
+    // spawn() ENOENT is async, so try/catch cannot catch missing binaries.
+    const openTermConfigs: Array<{ bin: string; args: string[] }> = [
+      { bin: 'gnome-terminal', args: ['--working-directory', cwd] },
+      { bin: 'konsole', args: ['--workdir', cwd] },
+      { bin: 'xterm', args: ['-e', `cd "${cwd}" && exec $SHELL`] },
+    ]
+    for (const { bin, args } of openTermConfigs) {
       try {
-        const args = term === 'gnome-terminal' ? ['--working-directory', cwd] : ['--workdir', cwd]
-        const child = spawn(term, args, {
-          detached: true,
-          stdio: 'ignore',
-        })
-        child.unref()
-        return { success: true, pid: child.pid }
+        execSync(`command -v ${bin}`, { stdio: 'ignore' })
       } catch {
         continue
       }
+      const child = spawn(bin, args, {
+        detached: true,
+        stdio: 'ignore',
+      })
+      child.unref()
+      return { success: true, pid: child.pid }
     }
 
     return { success: false, error: 'No supported terminal emulator found' }

--- a/packages/core/src/resume.ts
+++ b/packages/core/src/resume.ts
@@ -3,7 +3,12 @@
  * This module uses child_process and should NOT be imported in browser environments
  */
 import { spawn } from 'node:child_process'
-import type { ResumeSessionOptions, ResumeSessionResult, StartClaudeOptions } from './types.js'
+import type {
+  OpenExternalTerminalOptions,
+  ResumeSessionOptions,
+  ResumeSessionResult,
+  StartClaudeOptions,
+} from './types.js'
 
 /**
  * Start claude CLI in an external terminal window.
@@ -87,4 +92,68 @@ export const resumeSession = (options: ResumeSessionOptions): ResumeSessionResul
     command: `claude ${claudeArgs.join(' ')}`,
     cwd,
   })
+}
+
+/**
+ * Open the OS default terminal at the given directory without running a command.
+ * OS-specific: Terminal.app (macOS), cmd (Windows), gnome-terminal/konsole/xterm (Linux)
+ */
+export const openExternalTerminal = (options: OpenExternalTerminalOptions): ResumeSessionResult => {
+  const { cwd } = options
+
+  try {
+    if (process.platform === 'darwin') {
+      const escapedDir = cwd.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      const script = `
+tell application "Terminal"
+  activate
+  do script "cd \\"${escapedDir}\\""
+end tell
+tell application "System Events"
+  set frontmost of process "Terminal" to true
+end tell
+`
+      const child = spawn('osascript', ['-e', script], {
+        detached: true,
+        stdio: 'ignore',
+      })
+      child.unref()
+
+      return { success: true, pid: child.pid }
+    }
+
+    if (process.platform === 'win32') {
+      const child = spawn('cmd', ['/c', 'start', 'cmd', '/k', `cd /d "${cwd}"`], {
+        cwd,
+        detached: true,
+        stdio: 'ignore',
+      })
+      child.unref()
+
+      return { success: true, pid: child.pid }
+    }
+
+    // Linux: try common terminal emulators
+    const terminals = ['gnome-terminal', 'konsole', 'xterm']
+    for (const term of terminals) {
+      try {
+        const args = term === 'gnome-terminal' ? ['--working-directory', cwd] : ['--workdir', cwd]
+        const child = spawn(term, args, {
+          detached: true,
+          stdio: 'ignore',
+        })
+        child.unref()
+        return { success: true, pid: child.pid }
+      } catch {
+        continue
+      }
+    }
+
+    return { success: false, error: 'No supported terminal emulator found' }
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
 }

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -6,5 +6,10 @@
  * Usage: import { resumeSession } from '@claude-sessions/core/server'
  */
 
-export { resumeSession, startClaude } from './resume.js'
-export type { ResumeSessionOptions, ResumeSessionResult, StartClaudeOptions } from './types.js'
+export { openExternalTerminal, resumeSession, startClaude } from './resume.js'
+export type {
+  OpenExternalTerminalOptions,
+  ResumeSessionOptions,
+  ResumeSessionResult,
+  StartClaudeOptions,
+} from './types.js'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -425,6 +425,12 @@ export interface StartClaudeOptions {
   cwd?: string
 }
 
+/** Options for opening an external terminal at a directory */
+export interface OpenExternalTerminalOptions {
+  /** Working directory to open the terminal in */
+  cwd: string
+}
+
 export interface ResumeSessionOptions {
   /** Session ID to resume */
   sessionId: string

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { SessionTreeProvider, type SessionTreeItem } from './treeProvider'
 import * as session from '@claude-sessions/core'
-import { resumeSession, startClaude } from '@claude-sessions/core/server'
+import { openExternalTerminal, resumeSession, startClaude } from '@claude-sessions/core/server'
 import { Effect } from 'effect'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { outputChannel } from './output'
@@ -714,13 +714,53 @@ export function activate(context: vscode.ExtensionContext) {
       async (item: SessionTreeItem) => {
         if (!item || (item.type !== 'session' && item.type !== 'project')) return
 
+        const { defaultTerminalMode } = getConfig()
         const cwd = await resolveProjectCwd(item.projectName)
 
-        const terminal = vscode.window.createTerminal({
-          name: `Terminal: ${shortProjectName(item.projectName)}`,
-          cwd,
-        })
-        terminal.show()
+        let mode: 'internal' | 'external'
+        if (defaultTerminalMode === 'internal' || defaultTerminalMode === 'external') {
+          mode = defaultTerminalMode
+        } else {
+          const choice = await vscode.window.showQuickPick(
+            [
+              {
+                label: '$(terminal) Internal Terminal',
+                description: 'Open in VSCode integrated terminal',
+                mode: 'internal' as const,
+              },
+              {
+                label: '$(link-external) External Terminal',
+                description: 'Open in system default terminal',
+                mode: 'external' as const,
+              },
+            ],
+            {
+              placeHolder: 'Where to open terminal?',
+              title: 'Open Terminal Here',
+            }
+          )
+
+          if (!choice) return
+          mode = choice.mode
+        }
+
+        if (mode === 'internal') {
+          const terminal = vscode.window.createTerminal({
+            name: `Terminal: ${shortProjectName(item.projectName)}`,
+            cwd,
+          })
+          terminal.show()
+        } else {
+          const result = openExternalTerminal({ cwd })
+
+          if (result.success) {
+            vscode.window.showInformationMessage(
+              `Terminal opened in external terminal (PID: ${result.pid})`
+            )
+          } else {
+            vscode.window.showErrorMessage(`Failed to open external terminal: ${result.error}`)
+          }
+        }
       }
     ),
 


### PR DESCRIPTION
## Summary

Apply `defaultTerminalMode` setting to the `openTerminalHere` command, making it consistent with `resumeSession` and `startClaudeInFolder`.

- **Core**: Add `openExternalTerminal()` function to open OS default terminal at a directory without running a command (macOS Terminal.app, Windows cmd, Linux gnome-terminal/konsole/xterm)
- **Extension**: `openTerminalHere` now checks `claudeSessions.defaultTerminalMode` setting — supports `internal`, `external`, and `ask` modes
- **Tests**: 7 unit tests covering all OS platforms, error handling, and spawn verification

Closes #134

## Test plan

- [x] With `defaultTerminalMode: "internal"`, openTerminalHere opens VSCode integrated terminal
- [x] With `defaultTerminalMode: "external"`, openTerminalHere opens OS terminal at correct project path
- [x] With `defaultTerminalMode: "ask"`, openTerminalHere shows quick pick dialog
- [x] Quick pick cancel does nothing (no terminal opened)
- [x] VSCode extension tests pass: 17 passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Open external terminal directly from the editor at a specified directory across macOS, Windows, and Linux
  * New terminal mode preference setting (integrated or external) to control default behavior
  * Terminal launch now prompts for mode selection if no default is configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->