### PR TITLE
test(core): add unit tests for crud-helpers and tree-constants

### DIFF
--- a/packages/core/src/__tests__/crud-helpers.test.ts
+++ b/packages/core/src/__tests__/crud-helpers.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest'
+import {
+  filterSessionFiles,
+  buildSessionMeta,
+  sortSessionsByDate,
+} from '../session/crud-helpers.js'
+
+describe('filterSessionFiles', () => {
+  it('should include .jsonl files', () => {
+    const files = ['session-abc.jsonl', 'session-def.jsonl']
+    expect(filterSessionFiles(files)).toEqual(files)
+  })
+
+  it('should exclude agent files', () => {
+    const files = ['session-abc.jsonl', 'agent-xyz.jsonl', 'agent-123.jsonl']
+    expect(filterSessionFiles(files)).toEqual(['session-abc.jsonl'])
+  })
+
+  it('should exclude non-jsonl files', () => {
+    const files = ['session-abc.jsonl', 'sessions-index.json', 'README.md', '.DS_Store']
+    expect(filterSessionFiles(files)).toEqual(['session-abc.jsonl'])
+  })
+
+  it('should return empty array when no session files', () => {
+    const files = ['agent-xyz.jsonl', 'sessions-index.json']
+    expect(filterSessionFiles(files)).toEqual([])
+  })
+
+  it('should handle empty input', () => {
+    expect(filterSessionFiles([])).toEqual([])
+  })
+})
+
+describe('buildSessionMeta', () => {
+  it('should build metadata with explicit title', () => {
+    const meta = buildSessionMeta('session-id', 'project-name', {
+      title: 'My Session',
+      userAssistantCount: 10,
+      hasSummary: false,
+      firstTimestamp: '2026-01-01T00:00:00.000Z',
+      lastTimestamp: '2026-01-02T00:00:00.000Z',
+    })
+
+    expect(meta).toEqual({
+      id: 'session-id',
+      projectName: 'project-name',
+      title: 'My Session',
+      agentName: undefined,
+      customTitle: undefined,
+      currentSummary: undefined,
+      messageCount: 10,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    })
+  })
+
+  it('should use "[Summary Only]" title when no title but has summary', () => {
+    const meta = buildSessionMeta('session-id', 'project-name', {
+      userAssistantCount: 0,
+      hasSummary: true,
+    })
+
+    expect(meta.title).toBe('[Summary Only]')
+    expect(meta.messageCount).toBe(1)
+  })
+
+  it('should use truncated session ID as fallback title', () => {
+    const meta = buildSessionMeta('abcdef12-3456-7890-abcd-ef1234567890', 'project-name', {
+      userAssistantCount: 0,
+      hasSummary: false,
+    })
+
+    expect(meta.title).toBe('Session abcdef12')
+    expect(meta.messageCount).toBe(0)
+  })
+
+  it('should pass through agentName and customTitle', () => {
+    const meta = buildSessionMeta('session-id', 'project-name', {
+      title: 'Title',
+      agentName: 'My Agent',
+      customTitle: 'Custom Title',
+      currentSummary: 'Summary text',
+      userAssistantCount: 5,
+      hasSummary: false,
+    })
+
+    expect(meta.agentName).toBe('My Agent')
+    expect(meta.customTitle).toBe('Custom Title')
+    expect(meta.currentSummary).toBe('Summary text')
+  })
+
+  it('should count summary-only sessions as 1 message', () => {
+    const meta = buildSessionMeta('session-id', 'project-name', {
+      userAssistantCount: 0,
+      hasSummary: true,
+    })
+
+    expect(meta.messageCount).toBe(1)
+  })
+
+  it('should use userAssistantCount when messages exist', () => {
+    const meta = buildSessionMeta('session-id', 'project-name', {
+      userAssistantCount: 42,
+      hasSummary: true,
+    })
+
+    expect(meta.messageCount).toBe(42)
+  })
+})
+
+describe('sortSessionsByDate', () => {
+  it('should sort sessions newest first', () => {
+    const sessions = [
+      buildSessionMeta('old', 'proj', {
+        userAssistantCount: 1,
+        hasSummary: false,
+        lastTimestamp: '2026-01-01T00:00:00.000Z',
+      }),
+      buildSessionMeta('new', 'proj', {
+        userAssistantCount: 1,
+        hasSummary: false,
+        lastTimestamp: '2026-01-03T00:00:00.000Z',
+      }),
+      buildSessionMeta('mid', 'proj', {
+        userAssistantCount: 1,
+        hasSummary: false,
+        lastTimestamp: '2026-01-02T00:00:00.000Z',
+      }),
+    ]
+
+    const sorted = sortSessionsByDate(sessions)
+
+    expect(sorted[0].id).toBe('new')
+    expect(sorted[1].id).toBe('mid')
+    expect(sorted[2].id).toBe('old')
+  })
+
+  it('should handle sessions without updatedAt', () => {
+    const sessions = [
+      buildSessionMeta('with-date', 'proj', {
+        userAssistantCount: 1,
+        hasSummary: false,
+        lastTimestamp: '2026-01-01T00:00:00.000Z',
+      }),
+      buildSessionMeta('no-date', 'proj', { userAssistantCount: 1, hasSummary: false }),
+    ]
+
+    const sorted = sortSessionsByDate(sessions)
+
+    expect(sorted[0].id).toBe('with-date')
+    expect(sorted[1].id).toBe('no-date')
+  })
+
+  it('should handle empty array', () => {
+    expect(sortSessionsByDate([])).toEqual([])
+  })
+})

--- a/packages/core/src/__tests__/tree-constants.test.ts
+++ b/packages/core/src/__tests__/tree-constants.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { getTodoIcon, generateTreeNodeId, parseTreeNodeId, TREE_ICONS } from '../tree-constants.js'
+
+describe('getTodoIcon', () => {
+  it('should return completed icon with green color', () => {
+    const icon = getTodoIcon('completed')
+    expect(icon.codicon).toBe('pass-filled')
+    expect(icon.emoji).toBe('✅')
+    expect(icon.color).toBe('green')
+  })
+
+  it('should return in_progress icon with yellow color', () => {
+    const icon = getTodoIcon('in_progress')
+    expect(icon.codicon).toBe('sync~spin')
+    expect(icon.emoji).toBe('🔄')
+    expect(icon.color).toBe('yellow')
+  })
+
+  it('should return pending icon without color', () => {
+    const icon = getTodoIcon('pending')
+    expect(icon.codicon).toBe('circle-outline')
+    expect(icon.emoji).toBe('⭕')
+    expect(icon.color).toBeUndefined()
+  })
+
+  it('should return the same reference as TREE_ICONS.todo', () => {
+    expect(getTodoIcon('completed')).toBe(TREE_ICONS.todo.completed)
+    expect(getTodoIcon('in_progress')).toBe(TREE_ICONS.todo.in_progress)
+    expect(getTodoIcon('pending')).toBe(TREE_ICONS.todo.pending)
+  })
+})
+
+describe('generateTreeNodeId', () => {
+  it('should generate basic session node ID', () => {
+    const id = generateTreeNodeId('session', 'my-project', 'session-123')
+    expect(id).toBe('session:my-project:session-123')
+  })
+
+  it('should generate project node ID', () => {
+    const id = generateTreeNodeId('project', 'my-project', 'root')
+    expect(id).toBe('project:my-project:root')
+  })
+
+  it('should include agentId when provided', () => {
+    const id = generateTreeNodeId('agent', 'my-project', 'session-123', 'agent-456')
+    expect(id).toBe('agent:my-project:session-123:agent-456')
+  })
+
+  it('should include itemIndex when provided', () => {
+    const id = generateTreeNodeId('todo', 'my-project', 'session-123', 'agent-456', 0)
+    expect(id).toBe('todo:my-project:session-123:agent-456:0')
+  })
+
+  it('should include itemIndex even without agentId', () => {
+    const id = generateTreeNodeId('summary', 'my-project', 'session-123', undefined, 5)
+    expect(id).toBe('summary:my-project:session-123:5')
+  })
+
+  it('should handle special characters in project names', () => {
+    const id = generateTreeNodeId('session', '-Users-david-projects', 'session-abc')
+    expect(id).toBe('session:-Users-david-projects:session-abc')
+  })
+})
+
+describe('parseTreeNodeId', () => {
+  it('should parse basic session node ID', () => {
+    const result = parseTreeNodeId('session:my-project:session-123')
+    expect(result).toEqual({
+      type: 'session',
+      projectName: 'my-project',
+      sessionId: 'session-123',
+    })
+  })
+
+  it('should parse node ID with agentId', () => {
+    const result = parseTreeNodeId('agent:my-project:session-123:agent-456')
+    expect(result).toEqual({
+      type: 'agent',
+      projectName: 'my-project',
+      sessionId: 'session-123',
+      agentId: 'agent-456',
+    })
+  })
+
+  it('should parse node ID with agentId and itemIndex', () => {
+    const result = parseTreeNodeId('todo:my-project:session-123:agent-456:0')
+    expect(result).toEqual({
+      type: 'todo',
+      projectName: 'my-project',
+      sessionId: 'session-123',
+      agentId: 'agent-456',
+      itemIndex: 0,
+    })
+  })
+
+  it('should return null for invalid ID with fewer than 3 parts', () => {
+    expect(parseTreeNodeId('session:my-project')).toBeNull()
+    expect(parseTreeNodeId('session')).toBeNull()
+    expect(parseTreeNodeId('')).toBeNull()
+  })
+
+  it('should roundtrip with generateTreeNodeId', () => {
+    const original = {
+      type: 'todo' as const,
+      projectName: 'proj',
+      sessionId: 'sess',
+      agentId: 'ag',
+      itemIndex: 3,
+    }
+    const id = generateTreeNodeId(
+      original.type,
+      original.projectName,
+      original.sessionId,
+      original.agentId,
+      original.itemIndex
+    )
+    const parsed = parseTreeNodeId(id)
+    expect(parsed).toEqual(original)
+  })
+
+  it('should handle non-numeric itemIndex gracefully', () => {
+    const result = parseTreeNodeId('todo:proj:sess:agent:notanumber')
+    expect(result).toEqual({
+      type: 'todo',
+      projectName: 'proj',
+      sessionId: 'sess',
+      agentId: 'agent',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add 14 unit tests for `session/crud-helpers.ts` — `filterSessionFiles`, `buildSessionMeta`, `sortSessionsByDate`
- Add 16 unit tests for `tree-constants.ts` — `getTodoIcon`, `generateTreeNodeId`, `parseTreeNodeId`
- Both modules had 0% test coverage

## Test plan

- [x] `pnpm test -- crud-helpers tree-constants` — 30/30 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for session management operations and navigation tree functionality to improve code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->