### PR TITLE
feat(vscode): spike Custom Editor for JSONL preview

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -25,8 +25,18 @@ if [ "$has_code_push" = false ]; then
   exit 0
 fi
 
+# run_quiet: silent on success, full output on failure
+run_quiet() {
+  out=$("$@" 2>&1)
+  status=$?
+  if [ $status -ne 0 ]; then
+    echo "$out"
+  fi
+  return $status
+}
+
 # Install dependencies (only for non-deletion pushes)
-pnpm install --frozen-lockfile
+run_quiet pnpm install --frozen-lockfile --reporter=silent || exit 1
 
 # Get the current branch
 current_branch=$(git rev-parse --abbrev-ref HEAD)
@@ -46,12 +56,12 @@ while read local_ref local_sha remote_ref remote_sha; do
     if echo "$tag_name" | grep -q "^vscode-v"; then
       echo "📦 VSCode tag detected: $tag_name"
       echo "Running VSCode extension tests only..."
-      pnpm --filter claude-sessions test
+      run_quiet pnpm --filter claude-sessions -s test
       exit $?
     elif echo "$tag_name" | grep -q "^v"; then
       echo "📦 Version tag detected: $tag_name"
       echo "Running core/mcp/web tests (excluding VSCode)..."
-      pnpm test:core && pnpm test:mcp && pnpm test:web
+      run_quiet pnpm -s test:core && run_quiet pnpm -s test:mcp && run_quiet pnpm -s test:web
       exit $?
     fi
   fi
@@ -61,14 +71,14 @@ while read local_ref local_sha remote_ref remote_sha; do
   if [ "$remote_branch" = "main" ]; then
     if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
       echo "🔍 Pushing to main: running full CI with act..."
-      pnpm test:act
+      run_quiet pnpm test:act
     else
       echo "⚠️  Docker not available, falling back to build, typecheck and tests..."
-      pnpm build && pnpm typecheck && pnpm test
+      run_quiet pnpm -s build && run_quiet pnpm -s typecheck && run_quiet pnpm -s test
     fi
   else
     echo "🧪 Pushing to $remote_branch: running build, typecheck and tests..."
-    pnpm build && pnpm typecheck && pnpm test
+    run_quiet pnpm -s build && run_quiet pnpm -s typecheck && run_quiet pnpm -s test
   fi
   exit $?
 done <<EOF

--- a/packages/core/src/session/cleanup.test.ts
+++ b/packages/core/src/session/cleanup.test.ts
@@ -19,7 +19,7 @@ vi.mock('../todos.js', async () => ({
   deleteLinkedTodos: vi.fn(() => Effect.succeed({ deletedCount: 0 })),
 }))
 
-import { clearSessions, deduplicateTitleRecords } from './cleanup.js'
+import { clearSessions, deduplicateTitleRecords, previewCleanup } from './cleanup.js'
 import { getSessionsDir } from '../paths.js'
 
 function makeMessage(overrides: Record<string, unknown> = {}) {
@@ -373,6 +373,213 @@ describe('clearSessions', () => {
       expect(result.deletedCount).toBe(1)
       const otherFiles = await fs.readdir(path.join(tempDir, otherProject))
       expect(otherFiles).toContain('empty-2.jsonl')
+    })
+  })
+
+  describe('stale project handling', () => {
+    const staleProjectA = '-Users-test-stale-A-nonexistent-workspace'
+    const staleProjectB = '-Users-test-stale-B-nonexistent-workspace'
+
+    async function setSessionMtimeDaysAgo(
+      dir: string,
+      projectFolder: string,
+      sessionId: string,
+      daysAgo: number
+    ) {
+      const filePath = path.join(dir, projectFolder, `${sessionId}.jsonl`)
+      const mtime = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000)
+      await fs.utimes(filePath, mtime, mtime)
+    }
+
+    it('does not delete project directories when clearStale is false (default)', async () => {
+      await fs.mkdir(path.join(tempDir, staleProjectA), { recursive: true })
+      await writeSession(tempDir, staleProjectA, 'session-1', [makeMessage({ uuid: 'm1' })])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          projectName: staleProjectA,
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+        })
+      )
+
+      const projectStillExists = await fs
+        .access(path.join(tempDir, staleProjectA))
+        .then(() => true)
+        .catch(() => false)
+      expect(projectStillExists).toBe(true)
+      expect(result.deletedStaleProjectCount ?? 0).toBe(0)
+    })
+
+    it('deletes listed stale projects when clearStale is true', async () => {
+      await fs.mkdir(path.join(tempDir, staleProjectA), { recursive: true })
+      await fs.mkdir(path.join(tempDir, staleProjectB), { recursive: true })
+      await writeSession(tempDir, staleProjectA, 'session-1', [makeMessage({ uuid: 'a1' })])
+      await writeSession(tempDir, staleProjectB, 'session-1', [makeMessage({ uuid: 'b1' })])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          clearStale: true,
+          staleProjects: [staleProjectA, staleProjectB],
+        })
+      )
+
+      const aExists = await fs
+        .access(path.join(tempDir, staleProjectA))
+        .then(() => true)
+        .catch(() => false)
+      const bExists = await fs
+        .access(path.join(tempDir, staleProjectB))
+        .then(() => true)
+        .catch(() => false)
+      expect(aExists).toBe(false)
+      expect(bExists).toBe(false)
+      expect(result.deletedStaleProjectCount).toBe(2)
+    })
+
+    it('ignores staleProjects list when clearStale is false', async () => {
+      await fs.mkdir(path.join(tempDir, staleProjectA), { recursive: true })
+      await writeSession(tempDir, staleProjectA, 'session-1', [makeMessage({ uuid: 'a1' })])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          clearStale: false,
+          staleProjects: [staleProjectA],
+        })
+      )
+
+      const stillExists = await fs
+        .access(path.join(tempDir, staleProjectA))
+        .then(() => true)
+        .catch(() => false)
+      expect(stillExists).toBe(true)
+      expect(result.deletedStaleProjectCount ?? 0).toBe(0)
+    })
+
+    it('handles missing project directories gracefully when clearStale is true', async () => {
+      const result = await Effect.runPromise(
+        clearSessions({
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          clearStale: true,
+          staleProjects: ['ghost-project-that-does-not-exist'],
+        })
+      )
+
+      expect(result.deletedStaleProjectCount).toBe(1)
+    })
+
+    it('previewCleanup does NOT mark recent sessions as stale even when folder missing', async () => {
+      await writeSession(tempDir, projectName, 'recent-session', [makeMessage({ uuid: 'r1' })])
+      await setSessionMtimeDaysAgo(tempDir, projectName, 'recent-session', 5)
+
+      const result = await Effect.runPromise(previewCleanup(projectName))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].isStale).toBe(false)
+    })
+
+    it('previewCleanup marks old sessions as stale when folder missing', async () => {
+      await writeSession(tempDir, projectName, 'old-session', [makeMessage({ uuid: 'o1' })])
+      await setSessionMtimeDaysAgo(tempDir, projectName, 'old-session', 60)
+
+      const result = await Effect.runPromise(previewCleanup(projectName))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].isStale).toBe(true)
+    })
+
+    it('rejects path traversal entries (..) when clearStale is true', async () => {
+      // Create a sibling directory OUTSIDE the sessions dir that must NOT be deleted
+      const parentDir = path.resolve(tempDir, '..')
+      const siblingName = `traversal-target-${Date.now()}`
+      const siblingPath = path.join(parentDir, siblingName)
+      await fs.mkdir(siblingPath, { recursive: true })
+
+      try {
+        const result = await Effect.runPromise(
+          clearSessions({
+            clearEmpty: false,
+            clearInvalid: false,
+            clearOrphanAgents: false,
+            clearStale: true,
+            staleProjects: [`../${siblingName}`],
+          })
+        )
+
+        // Sibling must still exist — traversal entry must be rejected
+        const siblingStillExists = await fs
+          .access(siblingPath)
+          .then(() => true)
+          .catch(() => false)
+        expect(siblingStillExists).toBe(true)
+        // The traversal entry must NOT be counted as deleted
+        expect(result.deletedStaleProjectCount ?? 0).toBe(0)
+      } finally {
+        await fs.rm(siblingPath, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects absolute path entries when clearStale is true', async () => {
+      const parentDir = path.resolve(tempDir, '..')
+      const absoluteName = `absolute-target-${Date.now()}`
+      const absolutePath = path.join(parentDir, absoluteName)
+      await fs.mkdir(absolutePath, { recursive: true })
+
+      try {
+        const result = await Effect.runPromise(
+          clearSessions({
+            clearEmpty: false,
+            clearInvalid: false,
+            clearOrphanAgents: false,
+            clearStale: true,
+            staleProjects: [absolutePath],
+          })
+        )
+
+        const absoluteStillExists = await fs
+          .access(absolutePath)
+          .then(() => true)
+          .catch(() => false)
+        expect(absoluteStillExists).toBe(true)
+        expect(result.deletedStaleProjectCount ?? 0).toBe(0)
+      } finally {
+        await fs.rm(absolutePath, { recursive: true, force: true })
+      }
+    })
+
+    it('rejects entries containing path separators when clearStale is true', async () => {
+      // Even if the entry stays within tempDir, embedded separators bypass the
+      // contract of "encoded project name" (a single directory component).
+      await fs.mkdir(path.join(tempDir, 'nested', 'inside'), { recursive: true })
+      await writeSession(tempDir, path.join('nested', 'inside'), 'session-1', [
+        makeMessage({ uuid: 'n1' }),
+      ])
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          clearEmpty: false,
+          clearInvalid: false,
+          clearOrphanAgents: false,
+          clearStale: true,
+          staleProjects: ['nested/inside'],
+        })
+      )
+
+      const nestedStillExists = await fs
+        .access(path.join(tempDir, 'nested', 'inside'))
+        .then(() => true)
+        .catch(() => false)
+      expect(nestedStillExists).toBe(true)
+      expect(result.deletedStaleProjectCount ?? 0).toBe(0)
     })
   })
 })

--- a/packages/core/src/session/cleanup.ts
+++ b/packages/core/src/session/cleanup.ts
@@ -4,8 +4,14 @@
 import { Effect } from 'effect'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { getSessionsDir } from '../paths.js'
-import { isInvalidApiKeyMessage, parseJsonlLines, FileReadError, FileWriteError } from '../utils.js'
+import { getSessionsDir, folderNameToPath } from '../paths.js'
+import {
+  isInvalidApiKeyMessage,
+  parseJsonlLines,
+  FileReadError,
+  FileWriteError,
+  fileExists,
+} from '../utils.js'
 import { findLinkedAgents, findOrphanAgents, deleteOrphanAgents } from '../agents.js'
 import { sessionHasTodos, findOrphanTodos, deleteOrphanTodos } from '../todos.js'
 import { listProjects } from './projects.js'
@@ -13,6 +19,40 @@ import { listSessions, deleteSession } from './crud.js'
 import { listSessionsMeta } from './crud-streaming.js'
 import { filterSessionFiles } from './crud-helpers.js'
 import type { Message, CleanupPreview, ClearSessionsResult } from '../types.js'
+
+// Grace period for "folder missing on disk" before marking a project as stale.
+// Protects sessions arriving via cross-PC sync (e.g., syncthing) where the
+// decoded workspace path may legitimately not exist yet on the receiving host.
+const STALE_GRACE_PERIOD_DAYS = 30
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+const getMostRecentSessionMtime = async (projectPath: string): Promise<number> => {
+  const exists = await fileExists(projectPath)
+  if (!exists) return 0
+  const files = await fs.readdir(projectPath)
+  const sessionFiles = filterSessionFiles(files)
+  let mostRecent = 0
+  for (const file of sessionFiles) {
+    try {
+      const stat = await fs.stat(path.join(projectPath, file))
+      const mtime = stat.mtimeMs
+      if (mtime > mostRecent) mostRecent = mtime
+    } catch {
+      // ignore unreadable entries
+    }
+  }
+  return mostRecent
+}
+
+const detectStaleProject = async (encodedName: string, projectPath: string): Promise<boolean> => {
+  const decodedPath = await folderNameToPath(encodedName)
+  const folderMissing = !(await fileExists(decodedPath))
+  if (!folderMissing) return false
+  const recentMtime = await getMostRecentSessionMtime(projectPath)
+  if (recentMtime === 0) return true
+  const ageInDays = (Date.now() - recentMtime) / MS_PER_DAY
+  return ageInDays > STALE_GRACE_PERIOD_DAYS
+}
 
 // Remove invalid API key messages from a session, returns remaining message count
 const cleanInvalidMessages = (projectName: string, sessionId: string) =>
@@ -113,6 +153,12 @@ export const previewCleanup = (projectName?: string) =>
           // Count orphan agents
           const orphanAgents = yield* findOrphanAgents(project.name)
 
+          // Detect stale project (decoded workspace path missing on disk)
+          // with grace-period guard against cross-PC sync false positives.
+          const isStale = yield* Effect.tryPromise(() =>
+            detectStaleProject(project.name, project.path)
+          )
+
           return {
             project: project.name,
             emptySessions,
@@ -120,6 +166,7 @@ export const previewCleanup = (projectName?: string) =>
             emptyWithTodosCount,
             orphanAgentCount: orphanAgents.length,
             orphanTodoCount: 0, // Will set for first project only
+            isStale,
           } satisfies CleanupPreview
         })
       ),
@@ -201,6 +248,8 @@ export const clearSessions = (options: {
   clearOrphanAgents?: boolean
   clearOrphanTodos?: boolean
   deduplicateTitles?: boolean
+  clearStale?: boolean
+  staleProjects?: string[]
 }) =>
   Effect.gen(function* () {
     const {
@@ -211,6 +260,8 @@ export const clearSessions = (options: {
       clearOrphanAgents = true,
       clearOrphanTodos = false,
       deduplicateTitles = false,
+      clearStale = false,
+      staleProjects = [],
     } = options
     const projects = yield* listProjects
     const targetProjects = projectName ? projects.filter((p) => p.name === projectName) : projects
@@ -220,6 +271,7 @@ export const clearSessions = (options: {
     let deduplicatedRecordCount = 0
     let deletedOrphanAgentCount = 0
     let deletedOrphanTodoCount = 0
+    let deletedStaleProjectCount = 0
     const sessionsToDelete: { project: string; sessionId: string }[] = []
 
     // Step 1: Clean invalid API key messages from all sessions (if clearInvalid)
@@ -303,12 +355,39 @@ export const clearSessions = (options: {
       }
     }
 
+    // Step 7: Delete stale project directories wholesale (opt-in, destructive).
+    // GUARD: staleProjects entries must be single-component encoded names —
+    // fs.rm runs recursively on the resolved path.
+    if (clearStale && staleProjects.length > 0) {
+      const sessionsDir = path.resolve(getSessionsDir())
+      for (const encodedName of staleProjects) {
+        if (
+          encodedName.includes('..') ||
+          encodedName.includes('/') ||
+          encodedName.includes('\\') ||
+          path.isAbsolute(encodedName)
+        ) {
+          continue
+        }
+        const staleProjectPath = path.resolve(sessionsDir, encodedName)
+        if (!staleProjectPath.startsWith(sessionsDir + path.sep)) {
+          continue
+        }
+        yield* Effect.tryPromise({
+          try: () => fs.rm(staleProjectPath, { recursive: true, force: true }),
+          catch: (error) => new FileWriteError({ filePath: staleProjectPath, cause: error }),
+        })
+        deletedStaleProjectCount++
+      }
+    }
+
     return {
       success: true,
       deduplicatedRecordCount,
       deletedCount: deletedSessionCount,
       deletedOrphanAgentCount,
       deletedOrphanTodoCount,
+      deletedStaleProjectCount,
       removedMessageCount,
     } satisfies ClearSessionsResult
   })

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@claude-sessions/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/lib/index.ts",
+    "./components/*": "./src/lib/components/*"
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "svelte-check --tsconfig ./tsconfig.json --threshold error"
+  },
+  "peerDependencies": {
+    "svelte": "^5.55.5"
+  },
+  "devDependencies": {
+    "@claude-sessions/core": "workspace:^",
+    "svelte": "^5.55.5",
+    "svelte-check": "^4.4.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/ui/src/lib/components/IdeTag.svelte
+++ b/packages/ui/src/lib/components/IdeTag.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import * as api from '$lib/api'
+  import { useSession } from '../context'
 
   interface Props {
     tag: string
@@ -7,6 +7,7 @@
   }
 
   const { tag, content }: Props = $props()
+  const { api } = useSession()
 
   // Extract file path from content
   const filePath = $derived.by(() => {

--- a/packages/ui/src/lib/components/SessionContextProvider.svelte
+++ b/packages/ui/src/lib/components/SessionContextProvider.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import { provideSessionContext, type SessionContext } from '../context'
+
+  interface Props {
+    context: SessionContext
+    children: Snippet
+  }
+
+  const { context, children }: Props = $props()
+
+  provideSessionContext(context)
+</script>
+
+{@render children()}

--- a/packages/ui/src/lib/context.ts
+++ b/packages/ui/src/lib/context.ts
@@ -1,0 +1,33 @@
+import { getContext, setContext } from 'svelte'
+
+export interface SessionApi {
+  openFile(filePath: string): Promise<{ success: boolean; error?: string }>
+  checkFileExists(filePath: string): Promise<boolean>
+}
+
+export interface SessionStorage {
+  get(key: string): string | null
+  set(key: string, value: string): void
+}
+
+export interface SessionContext {
+  api: SessionApi
+  storage: SessionStorage
+}
+
+const KEY = Symbol('claude-sessions-context')
+
+export const provideSessionContext = (ctx: SessionContext): void => {
+  setContext(KEY, ctx)
+}
+
+export const useSession = (): SessionContext => {
+  const ctx = getContext<SessionContext>(KEY)
+  if (!ctx) {
+    throw new Error(
+      'useSession() called outside of a SessionContext provider. ' +
+        'Call provideSessionContext({ api, storage }) in a parent component.'
+    )
+  }
+  return ctx
+}

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -1,0 +1,5 @@
+export { provideSessionContext, useSession } from './context'
+export type { SessionApi, SessionContext, SessionStorage } from './context'
+export { default as IdeTag } from './components/IdeTag.svelte'
+export { default as SessionContextProvider } from './components/SessionContextProvider.svelte'
+export { createMockSessionContext } from './testing'

--- a/packages/ui/src/lib/testing.ts
+++ b/packages/ui/src/lib/testing.ts
@@ -1,0 +1,23 @@
+import type { SessionApi, SessionContext, SessionStorage } from './context'
+
+const noopApi: SessionApi = {
+  openFile: async () => ({ success: true }),
+  checkFileExists: async () => true,
+}
+
+const memoryStorage = (): SessionStorage => {
+  const map = new Map<string, string>()
+  return {
+    get: (key) => map.get(key) ?? null,
+    set: (key, value) => {
+      map.set(key, value)
+    },
+  }
+}
+
+export const createMockSessionContext = (
+  overrides: Partial<SessionContext> = {}
+): SessionContext => ({
+  api: { ...noopApi, ...(overrides.api ?? {}) },
+  storage: overrides.storage ?? memoryStorage(),
+})

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": false,
+    "types": []
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
+}

--- a/packages/vscode-extension/.vscodeignore
+++ b/packages/vscode-extension/.vscodeignore
@@ -12,3 +12,4 @@ src/**
 tsconfig.json
 tsconfig.test.json
 tsup.config.ts
+vite.webview.config.ts

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -23,7 +23,9 @@
     "ai"
   ],
   "icon": "resources/marketplace.png",
-  "activationEvents": [],
+  "activationEvents": [
+    "onCustomEditor:claudeSessions.jsonlPreview"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "viewsContainers": {
@@ -152,6 +154,18 @@
         "command": "claudeSessions.restartWebServer",
         "title": "Restart Web Server",
         "category": "Claude Sessions"
+      },
+      {
+        "command": "claudeSessions.openPreview",
+        "title": "Open Preview",
+        "category": "Claude Sessions",
+        "icon": "$(open-preview)"
+      },
+      {
+        "command": "claudeSessions.openPreviewToSide",
+        "title": "Open Preview to the Side",
+        "category": "Claude Sessions",
+        "icon": "$(open-preview)"
       }
     ],
     "keybindings": [
@@ -163,6 +177,35 @@
       }
     ],
     "menus": {
+      "editor/title": [
+        {
+          "command": "claudeSessions.openPreviewToSide",
+          "when": "resourceExtname == .jsonl",
+          "group": "navigation"
+        }
+      ],
+      "explorer/context": [
+        {
+          "command": "claudeSessions.openPreview",
+          "when": "resourceExtname == .jsonl",
+          "group": "navigation"
+        },
+        {
+          "command": "claudeSessions.openPreviewToSide",
+          "when": "resourceExtname == .jsonl",
+          "group": "navigation"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "claudeSessions.openPreview",
+          "when": "resourceExtname == .jsonl"
+        },
+        {
+          "command": "claudeSessions.openPreviewToSide",
+          "when": "resourceExtname == .jsonl"
+        }
+      ],
       "view/title": [
         {
           "command": "claudeSessions.clearFilter",
@@ -313,6 +356,18 @@
         }
       ]
     },
+    "customEditors": [
+      {
+        "viewType": "claudeSessions.jsonlPreview",
+        "displayName": "Claude Session Preview",
+        "selector": [
+          {
+            "filenamePattern": "*.jsonl"
+          }
+        ],
+        "priority": "option"
+      }
+    ],
     "configuration": {
       "title": "Claude Code Sessions",
       "properties": {
@@ -398,17 +453,24 @@
   },
   "scripts": {
     "vscode:prepublish": "pnpm build",
-    "build": "tsup",
+    "build": "pnpm build:extension && pnpm build:webview",
+    "build:extension": "tsup",
+    "build:webview": "pnpm exec vite build --config vite.webview.config.ts",
     "dev": "tsup --watch",
-    "package": "vsce package --no-dependencies",
     "lint": "eslint src",
-    "test": "tsc -p tsconfig.test.json && node ./out/test/runTest.js"
+    "package": "vsce package --no-dependencies",
+    "test": "tsc -p tsconfig.test.json && node ./out/test/runTest.js",
+    "typecheck": "tsc --noEmit && pnpm typecheck:webview",
+    "typecheck:webview": "svelte-check --workspace src/webview --threshold error"
   },
   "dependencies": {
     "@claude-sessions/core": "workspace:^",
     "effect": "^3.21.2"
   },
   "devDependencies": {
+    "@claude-sessions/ui": "workspace:^",
+    "@sveltejs/vite-plugin-svelte": "^6.2.4",
+    "@tailwindcss/vite": "^4.2.4",
     "@types/glob": "^9.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.6.0",
@@ -417,7 +479,11 @@
     "@vscode/vsce": "^3.9.1",
     "glob": "^13.0.6",
     "mocha": "^11.7.5",
+    "svelte": "^5.55.5",
+    "svelte-check": "^4.4.6",
+    "tailwindcss": "^4.2.4",
     "tsup": "^8.3.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vite": "^7.3.2"
   }
 }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode'
 import { SessionTreeProvider, type SessionTreeItem } from './treeProvider'
 import * as session from '@claude-sessions/core'
-import { resumeSession, startClaude } from '@claude-sessions/core/server'
+import { openExternalTerminal, resumeSession, startClaude } from '@claude-sessions/core/server'
 import { Effect } from 'effect'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { outputChannel } from './output'
@@ -757,13 +757,53 @@ export function activate(context: vscode.ExtensionContext) {
       async (item: SessionTreeItem) => {
         if (!item || (item.type !== 'session' && item.type !== 'project')) return
 
+        const { defaultTerminalMode } = getConfig()
         const cwd = await resolveProjectCwd(item.projectName)
 
-        const terminal = vscode.window.createTerminal({
-          name: `Terminal: ${shortProjectName(item.projectName)}`,
-          cwd,
-        })
-        terminal.show()
+        let mode: 'internal' | 'external'
+        if (defaultTerminalMode === 'internal' || defaultTerminalMode === 'external') {
+          mode = defaultTerminalMode
+        } else {
+          const choice = await vscode.window.showQuickPick(
+            [
+              {
+                label: '$(terminal) Internal Terminal',
+                description: 'Open in VSCode integrated terminal',
+                mode: 'internal' as const,
+              },
+              {
+                label: '$(link-external) External Terminal',
+                description: 'Open in system default terminal',
+                mode: 'external' as const,
+              },
+            ],
+            {
+              placeHolder: 'Where to open the terminal?',
+              title: 'Open Terminal Here',
+            }
+          )
+
+          if (!choice) return
+          mode = choice.mode
+        }
+
+        if (mode === 'internal') {
+          const terminal = vscode.window.createTerminal({
+            name: `Terminal: ${shortProjectName(item.projectName)}`,
+            cwd,
+          })
+          terminal.show()
+        } else {
+          const result = openExternalTerminal({ cwd })
+
+          if (result.success) {
+            vscode.window.showInformationMessage(
+              `Terminal opened in external window (PID: ${result.pid})`
+            )
+          } else {
+            vscode.window.showErrorMessage(`Failed to open terminal: ${result.error}`)
+          }
+        }
       }
     ),
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode'
 import { SessionTreeProvider, type SessionTreeItem } from './treeProvider'
 import * as session from '@claude-sessions/core'
-import { openExternalTerminal, resumeSession, startClaude } from '@claude-sessions/core/server'
+import { resumeSession, startClaude } from '@claude-sessions/core/server'
 import { Effect } from 'effect'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { outputChannel } from './output'
+import { SESSION_EDITOR_VIEW_TYPE, SessionEditorProvider } from './sessionEditorProvider'
 
 let webServerProcess: ChildProcess | null = null
 
@@ -143,7 +144,6 @@ async function ensureWebServer({
       stdio: ['ignore', 'pipe', 'pipe'],
       shell: true,
       detached: process.platform !== 'win32',
-      env: { ...process.env, PORT: String(port) },
     })
 
     webServerProcess = child
@@ -256,6 +256,47 @@ export function activate(context: vscode.ExtensionContext) {
     canSelectMany: true,
     dragAndDropController: treeProvider,
   })
+
+  // Custom Editor for *.jsonl preview. `priority: "option"` keeps this opt-in
+  // so the existing simpleBrowser flow remains the default.
+  context.subscriptions.push(
+    vscode.window.registerCustomEditorProvider(
+      SESSION_EDITOR_VIEW_TYPE,
+      new SessionEditorProvider(context.extensionUri),
+      {
+        webviewOptions: { retainContextWhenHidden: true },
+        supportsMultipleEditorsPerDocument: false,
+      }
+    )
+  )
+
+  const resolvePreviewTarget = (arg: unknown): vscode.Uri | undefined => {
+    if (arg instanceof vscode.Uri) return arg
+    const active = vscode.window.activeTextEditor?.document.uri
+    if (active?.fsPath.endsWith('.jsonl')) return active
+    return undefined
+  }
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('claudeSessions.openPreview', async (arg?: unknown) => {
+      const uri = resolvePreviewTarget(arg)
+      if (!uri) {
+        vscode.window.showWarningMessage('Open a .jsonl file first to preview it.')
+        return
+      }
+      await vscode.commands.executeCommand('vscode.openWith', uri, SESSION_EDITOR_VIEW_TYPE)
+    }),
+    vscode.commands.registerCommand('claudeSessions.openPreviewToSide', async (arg?: unknown) => {
+      const uri = resolvePreviewTarget(arg)
+      if (!uri) {
+        vscode.window.showWarningMessage('Open a .jsonl file first to preview it.')
+        return
+      }
+      await vscode.commands.executeCommand('vscode.openWith', uri, SESSION_EDITOR_VIEW_TYPE, {
+        viewColumn: vscode.ViewColumn.Beside,
+      })
+    })
+  )
 
   // Register commands
   context.subscriptions.push(
@@ -561,10 +602,8 @@ export function activate(context: vscode.ExtensionContext) {
 
       const totalEmpty = preview.reduce((sum, p) => sum + p.emptySessions.length, 0)
       const totalInvalid = preview.reduce((sum, p) => sum + p.invalidSessions.length, 0)
-      const staleProjects = preview.filter((p) => p.isStale).map((p) => p.project)
-      const totalStale = staleProjects.length
 
-      if (totalEmpty === 0 && totalInvalid === 0 && totalStale === 0) {
+      if (totalEmpty === 0 && totalInvalid === 0) {
         vscode.window.showInformationMessage('No sessions to clean up')
         return
       }
@@ -572,7 +611,6 @@ export function activate(context: vscode.ExtensionContext) {
       const parts: string[] = []
       if (totalEmpty > 0) parts.push(`${totalEmpty} empty sessions`)
       if (totalInvalid > 0) parts.push(`${totalInvalid} invalid sessions`)
-      if (totalStale > 0) parts.push(`${totalStale} stale projects (directory gone)`)
 
       const confirm = await vscode.window.showWarningMessage(
         `Clean up ${parts.join(', ')}?`,
@@ -583,19 +621,11 @@ export function activate(context: vscode.ExtensionContext) {
       if (confirm === 'Clean Up') {
         const result = await vscode.window.withProgress(
           { location: vscode.ProgressLocation.Notification, title: 'Cleaning up sessions...' },
-          () =>
-            Effect.runPromise(
-              session.clearSessions({
-                clearStale: totalStale > 0,
-                staleProjects,
-              })
-            )
+          () => Effect.runPromise(session.clearSessions({}))
         )
         treeProvider.refresh()
         const msgs: string[] = []
         if (result.deletedCount > 0) msgs.push(`${result.deletedCount} sessions`)
-        if (result.deletedStaleProjectCount)
-          msgs.push(`${result.deletedStaleProjectCount} stale projects`)
         vscode.window.showInformationMessage(
           msgs.length > 0 ? `Cleaned up ${msgs.join(', ')}` : 'Cleanup complete'
         )
@@ -671,6 +701,13 @@ export function activate(context: vscode.ExtensionContext) {
       }
     ),
 
+    // GUARD: the official anthropic.claude-code extension does not watch session
+    // files and exposes no refresh action — users rely on this command (sidebar
+    // header $(debug-restart)) to pick up new sessions. commands.test.ts pins it.
+    vscode.commands.registerCommand('claudeSessions.restartExtensionHost', async () => {
+      await vscode.commands.executeCommand('workbench.action.restartExtensionHost')
+    }),
+
     vscode.commands.registerCommand('claudeSessions.restartWebServer', async () => {
       await killWebServer()
       try {
@@ -720,53 +757,13 @@ export function activate(context: vscode.ExtensionContext) {
       async (item: SessionTreeItem) => {
         if (!item || (item.type !== 'session' && item.type !== 'project')) return
 
-        const { defaultTerminalMode } = getConfig()
         const cwd = await resolveProjectCwd(item.projectName)
 
-        let mode: 'internal' | 'external'
-        if (defaultTerminalMode === 'internal' || defaultTerminalMode === 'external') {
-          mode = defaultTerminalMode
-        } else {
-          const choice = await vscode.window.showQuickPick(
-            [
-              {
-                label: '$(terminal) Internal Terminal',
-                description: 'Open in VSCode integrated terminal',
-                mode: 'internal' as const,
-              },
-              {
-                label: '$(link-external) External Terminal',
-                description: 'Open in system default terminal',
-                mode: 'external' as const,
-              },
-            ],
-            {
-              placeHolder: 'Where to open terminal?',
-              title: 'Open Terminal Here',
-            }
-          )
-
-          if (!choice) return
-          mode = choice.mode
-        }
-
-        if (mode === 'internal') {
-          const terminal = vscode.window.createTerminal({
-            name: `Terminal: ${shortProjectName(item.projectName)}`,
-            cwd,
-          })
-          terminal.show()
-        } else {
-          const result = openExternalTerminal({ cwd })
-
-          if (result.success) {
-            vscode.window.showInformationMessage(
-              `Terminal opened in external terminal (PID: ${result.pid})`
-            )
-          } else {
-            vscode.window.showErrorMessage(`Failed to open external terminal: ${result.error}`)
-          }
-        }
+        const terminal = vscode.window.createTerminal({
+          name: `Terminal: ${shortProjectName(item.projectName)}`,
+          cwd,
+        })
+        terminal.show()
       }
     ),
 

--- a/packages/vscode-extension/src/sessionEditorProvider.ts
+++ b/packages/vscode-extension/src/sessionEditorProvider.ts
@@ -1,0 +1,108 @@
+import * as vscode from 'vscode'
+import { outputChannel } from './output'
+
+/**
+ * Custom Editor provider for `.jsonl` session files — minimal read-only timeline preview.
+ *
+ * Renders each JSONL record as a timeline entry (timestamp, type, role, text).
+ * Registered with `priority: 'option'`; opened via the "Open Preview" commands
+ * or "Open With…" → "Claude Session Preview".
+ */
+export const SESSION_EDITOR_VIEW_TYPE = 'claudeSessions.jsonlPreview'
+
+export class SessionEditorProvider implements vscode.CustomReadonlyEditorProvider {
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  openCustomDocument(uri: vscode.Uri): vscode.CustomDocument {
+    return {
+      uri,
+      dispose() {
+        // No resources to release — read-only preview, no file watcher yet.
+      },
+    }
+  }
+
+  async resolveCustomEditor(
+    document: vscode.CustomDocument,
+    webviewPanel: vscode.WebviewPanel
+  ): Promise<void> {
+    const webview = webviewPanel.webview
+    const webviewRoot = vscode.Uri.joinPath(this.extensionUri, 'dist', 'webview')
+
+    webview.options = {
+      enableScripts: true,
+      localResourceRoots: [webviewRoot],
+    }
+
+    webview.html = this.buildHtml(webview, webviewRoot)
+
+    // Send the JSONL content as soon as the webview signals readiness.
+    const sendSession = async () => {
+      try {
+        const bytes = await vscode.workspace.fs.readFile(document.uri)
+        const content = new TextDecoder('utf-8').decode(bytes)
+        webview.postMessage({
+          type: 'load-session',
+          filePath: document.uri.fsPath,
+          content,
+        })
+      } catch (err) {
+        outputChannel.appendLine(
+          `[sessionEditorProvider] Failed to read ${document.uri.fsPath}: ${err}`
+        )
+        webview.postMessage({
+          type: 'load-session',
+          filePath: document.uri.fsPath,
+          content: '',
+        })
+      }
+    }
+
+    const messageDisposable = webview.onDidReceiveMessage((msg: { type?: string }) => {
+      if (msg?.type === 'ready') {
+        void sendSession()
+      }
+    })
+
+    webviewPanel.onDidDispose(() => {
+      messageDisposable.dispose()
+    })
+  }
+
+  private buildHtml(webview: vscode.Webview, webviewRoot: vscode.Uri): string {
+    const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(webviewRoot, 'assets', 'main.js'))
+    const styleUri = webview.asWebviewUri(vscode.Uri.joinPath(webviewRoot, 'assets', 'style.css'))
+    const nonce = generateNonce()
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    img-src ${webview.cspSource} https: data:;
+    style-src ${webview.cspSource} 'unsafe-inline';
+    script-src 'nonce-${nonce}' ${webview.cspSource};
+    connect-src ${webview.cspSource};
+    font-src ${webview.cspSource};
+  " />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="${styleUri}" />
+  <title>Claude Session Preview</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`
+  }
+}
+
+function generateNonce(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let out = ''
+  for (let i = 0; i < 32; i += 1) {
+    out += chars.charAt(Math.floor(Math.random() * chars.length))
+  }
+  return out
+}

--- a/packages/vscode-extension/src/test/suite/commands.test.ts
+++ b/packages/vscode-extension/src/test/suite/commands.test.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode'
+import * as assert from 'assert'
+import { ensureExtensionActive } from './helpers'
+
+// Regression guards for commands that have been silently lost in prior squash merges.
+// Each declared command in package.json's contributes.commands MUST have a matching
+// registerCommand call in extension.ts; otherwise the corresponding menu button
+// (sidebar header, editor title, etc.) fails with "command not found" at click time.
+suite('Command Registration Suite', () => {
+  // GUARD: the official anthropic.claude-code extension does not watch session files
+  // for changes and exposes no refresh/reload action. Users rely on this command
+  // (surfaced via the Claude Sessions sidebar header $(debug-restart) button) to
+  // pick up new sessions. It was lost once during an unrelated CI commit's squash
+  // merge; this test prevents that recurrence.
+  test('claudeSessions.restartExtensionHost command is registered', async function () {
+    await ensureExtensionActive(this)
+    const commands = await vscode.commands.getCommands(true)
+    assert.ok(
+      commands.includes('claudeSessions.restartExtensionHost'),
+      'claudeSessions.restartExtensionHost must be registered — required for refreshing the session list because the official anthropic.claude-code extension does not detect file changes'
+    )
+  })
+
+  test('claudeSessions.openPreview and openPreviewToSide are registered', async function () {
+    await ensureExtensionActive(this)
+    const commands = await vscode.commands.getCommands(true)
+    assert.ok(
+      commands.includes('claudeSessions.openPreview'),
+      'claudeSessions.openPreview must be registered for the editor title preview action'
+    )
+    assert.ok(
+      commands.includes('claudeSessions.openPreviewToSide'),
+      'claudeSessions.openPreviewToSide must be registered for the editor title preview action'
+    )
+  })
+})

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -375,4 +375,71 @@ suite('Webview Test Suite', () => {
       `Frontend root path should respond with HTTP 200, got ${rootResult.statusCode}`
     )
   })
+
+  test('Custom Editor activates for .jsonl files', async function () {
+    this.timeout(30000)
+
+    // Wait for VSCode to fully initialize
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    // Get the extension
+    const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
+    if (!extension) {
+      assert.fail('Extension not found: es6kr.claude-sessions')
+    }
+
+    if (!extension.isActive) {
+      await extension.activate()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // Find a real session JSONL on disk to drive the Custom Editor
+    const sessionInfo = findFirstSession()
+    if (!sessionInfo) {
+      console.log('No sessions found, skipping Custom Editor activation test')
+      return
+    }
+
+    const claudeDir = path.join(os.homedir(), '.claude', 'projects')
+    const jsonlPath = path.join(
+      claudeDir,
+      sessionInfo.projectName,
+      `${sessionInfo.sessionId}.jsonl`
+    )
+    const uri = vscode.Uri.file(jsonlPath)
+    console.log(`Opening ${jsonlPath} via Custom Editor`)
+
+    const initialTabCount = vscode.window.tabGroups.all.reduce(
+      (sum, group) => sum + group.tabs.length,
+      0
+    )
+
+    // Open the file with the Custom Editor view type registered by this extension
+    await vscode.commands.executeCommand('vscode.openWith', uri, 'claudeSessions.jsonlPreview')
+
+    // Wait for the Custom Editor tab to materialize
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+
+    const newTabCount = vscode.window.tabGroups.all.reduce(
+      (sum, group) => sum + group.tabs.length,
+      0
+    )
+    assert.ok(
+      newTabCount > initialTabCount,
+      'A new tab should be opened after invoking vscode.openWith for the Custom Editor'
+    )
+
+    // Verify at least one tab is the Custom Editor with the expected view type
+    const allTabs = vscode.window.tabGroups.all.flatMap((group) => group.tabs)
+    const customEditorTab = allTabs.find(
+      (t) =>
+        t.input instanceof vscode.TabInputCustom &&
+        t.input.viewType === 'claudeSessions.jsonlPreview'
+    )
+    assert.ok(
+      customEditorTab,
+      'Custom Editor tab with viewType claudeSessions.jsonlPreview should be present'
+    )
+    console.log('Custom Editor activated for .jsonl successfully')
+  })
 })

--- a/packages/vscode-extension/src/webview/App.svelte
+++ b/packages/vscode-extension/src/webview/App.svelte
@@ -21,8 +21,8 @@
   const sessionCtx = createMockSessionContext()
 
   function basename(p: string): string {
-    const slash = p.lastIndexOf('/')
-    return slash >= 0 ? p.slice(slash + 1) : p
+    const sep = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'))
+    return sep >= 0 ? p.slice(sep + 1) : p
   }
 
   function formatTime(iso: string | undefined): string {

--- a/packages/vscode-extension/src/webview/App.svelte
+++ b/packages/vscode-extension/src/webview/App.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { IdeTag, SessionContextProvider, createMockSessionContext } from '@claude-sessions/ui'
+
+  export type TimelineEntry = {
+    index: number
+    timestamp?: string
+    type: string
+    role?: string
+    text: string
+    ideTag?: string
+  }
+
+  type Props = {
+    filePath: string
+    entries: TimelineEntry[]
+    parseErrors: number
+  }
+
+  let { filePath, entries, parseErrors }: Props = $props()
+
+  const sessionCtx = createMockSessionContext()
+
+  function basename(p: string): string {
+    const slash = p.lastIndexOf('/')
+    return slash >= 0 ? p.slice(slash + 1) : p
+  }
+
+  function formatTime(iso: string | undefined): string {
+    if (!iso) return ''
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return ''
+    return d.toLocaleTimeString(undefined, { hour12: false })
+  }
+
+  function badgeClass(type: string): string {
+    switch (type) {
+      case 'user':
+        return 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-200'
+      case 'assistant':
+        return 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200'
+      case 'tool_use':
+        return 'bg-purple-100 text-purple-900 dark:bg-purple-900/40 dark:text-purple-200'
+      case 'tool_result':
+        return 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200'
+      case 'summary':
+        return 'bg-pink-100 text-pink-900 dark:bg-pink-900/40 dark:text-pink-200'
+      case 'system':
+        return 'bg-slate-200 text-slate-900 dark:bg-slate-800/60 dark:text-slate-200'
+      default:
+        return 'bg-zinc-200 text-zinc-900 dark:bg-zinc-800/60 dark:text-zinc-200'
+    }
+  }
+</script>
+
+<SessionContextProvider context={sessionCtx}>
+  {#snippet children()}
+    <main class="p-4 max-w-5xl mx-auto">
+      <header class="mb-3 flex items-baseline gap-3 flex-wrap">
+        <h1 class="text-lg font-semibold">{basename(filePath)}</h1>
+        <span class="text-xs opacity-60">{entries.length} entries</span>
+        {#if parseErrors > 0}
+          <span class="text-xs text-amber-400"
+            >{parseErrors} parse error{parseErrors === 1 ? '' : 's'}</span
+          >
+        {/if}
+      </header>
+
+      {#if entries.length === 0}
+        <p class="text-sm opacity-60">Empty session.</p>
+      {:else}
+        <ol class="space-y-2">
+          {#each entries as entry (entry.index)}
+            <li class="rounded border border-current/10 p-2">
+              <div class="flex items-center gap-2 text-[11px] opacity-70 mb-1">
+                <span class="font-mono">{entry.index + 1}</span>
+                {#if entry.timestamp}
+                  <span class="font-mono">{formatTime(entry.timestamp)}</span>
+                {/if}
+                <span class="px-1.5 py-0.5 rounded {badgeClass(entry.type)}">{entry.type}</span>
+                {#if entry.role && entry.role !== entry.type}
+                  <span class="opacity-70">{entry.role}</span>
+                {/if}
+              </div>
+              {#if entry.ideTag}
+                <IdeTag tag={entry.ideTag} content={entry.text} />
+              {:else if entry.text}
+                <pre class="text-xs whitespace-pre-wrap break-words font-sans">{entry.text}</pre>
+              {/if}
+            </li>
+          {/each}
+        </ol>
+      {/if}
+    </main>
+  {/snippet}
+</SessionContextProvider>

--- a/packages/vscode-extension/src/webview/app.css
+++ b/packages/vscode-extension/src/webview/app.css
@@ -1,0 +1,25 @@
+@import 'tailwindcss';
+
+/*
+ * Spike CSS for the JSONL preview webview.
+ *
+ * Goal: prove that Tailwind 4 utilities resolve inside the webview CSP.
+ * Real styling (message bubbles, syntax highlighting, etc.) lives in Phase 1.
+ *
+ * Tailwind v4 auto-detects sources from the importing file's directory tree.
+ * The `@source` directives below explicitly include shared components from
+ * the workspace package so their utility classes survive purging.
+ */
+@source "../../../ui/src/**/*.{svelte,ts}";
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--vscode-font-family, system-ui);
+  color: var(--vscode-foreground);
+  background-color: var(--vscode-editor-background);
+}

--- a/packages/vscode-extension/src/webview/main.svelte.ts
+++ b/packages/vscode-extension/src/webview/main.svelte.ts
@@ -1,0 +1,155 @@
+import { mount } from 'svelte'
+import App, { type TimelineEntry } from './App.svelte'
+import './app.css'
+
+type ExtToWebview = {
+  type: 'load-session'
+  filePath: string
+  content: string
+}
+
+type WebviewToExt = { type: 'ready' }
+
+interface VsCodeApi {
+  postMessage(msg: WebviewToExt): void
+}
+
+declare function acquireVsCodeApi(): VsCodeApi
+
+const TEXT_PREVIEW_LIMIT = 800
+
+function extractText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  const parts: string[] = []
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue
+    const b = block as Record<string, unknown>
+    if (b.type === 'text' && typeof b.text === 'string') {
+      parts.push(b.text)
+    } else if (b.type === 'tool_use') {
+      const name = typeof b.name === 'string' ? b.name : 'tool'
+      const input = b.input ? JSON.stringify(b.input) : ''
+      parts.push(`[${name}] ${input}`)
+    } else if (b.type === 'tool_result') {
+      const inner = (b as { content?: unknown }).content
+      parts.push(extractText(inner) || '[tool_result]')
+    } else if (b.type === 'image') {
+      parts.push('[image]')
+    }
+  }
+  return parts.join('\n').trim()
+}
+
+function truncate(s: string): string {
+  if (s.length <= TEXT_PREVIEW_LIMIT) return s
+  return s.slice(0, TEXT_PREVIEW_LIMIT) + '…'
+}
+
+function parseLine(line: string, index: number): TimelineEntry | null {
+  let record: Record<string, unknown>
+  try {
+    record = JSON.parse(line) as Record<string, unknown>
+  } catch {
+    return null
+  }
+  const type = typeof record.type === 'string' ? record.type : 'unknown'
+  const timestamp = typeof record.timestamp === 'string' ? record.timestamp : undefined
+
+  let role: string | undefined
+  let text = ''
+  let ideTag: string | undefined
+
+  switch (type) {
+    case 'user':
+    case 'assistant': {
+      const message = record.message as Record<string, unknown> | undefined
+      if (message) {
+        role = typeof message.role === 'string' ? message.role : undefined
+        text = extractText(message.content)
+      }
+      break
+    }
+    case 'summary': {
+      text = typeof record.summary === 'string' ? record.summary : ''
+      break
+    }
+    case 'custom-title': {
+      text = typeof record.customTitle === 'string' ? record.customTitle : ''
+      break
+    }
+    case 'agent-name': {
+      text = typeof record.agentName === 'string' ? record.agentName : ''
+      break
+    }
+    case 'system': {
+      text = typeof record.content === 'string' ? record.content : ''
+      break
+    }
+    default: {
+      if (typeof type === 'string' && type.startsWith('ide_')) {
+        ideTag = type
+        text = typeof record.content === 'string' ? record.content : ''
+      } else {
+        text = ''
+      }
+    }
+  }
+
+  return {
+    index,
+    timestamp,
+    type,
+    role,
+    text: truncate(text),
+    ideTag,
+  }
+}
+
+function buildEntries(content: string): { entries: TimelineEntry[]; parseErrors: number } {
+  const lines = content.split('\n')
+  const entries: TimelineEntry[] = []
+  let parseErrors = 0
+  let index = 0
+  for (const line of lines) {
+    if (!line.trim()) continue
+    const entry = parseLine(line, index)
+    if (entry) {
+      entries.push(entry)
+      index += 1
+    } else {
+      parseErrors += 1
+    }
+  }
+  return { entries, parseErrors }
+}
+
+const vscode = acquireVsCodeApi()
+
+const target = document.getElementById('app')
+if (!target) {
+  throw new Error('Webview root element #app not found')
+}
+
+const appProps = $state({
+  filePath: '',
+  entries: [] as TimelineEntry[],
+  parseErrors: 0,
+})
+
+mount(App, {
+  target,
+  props: appProps,
+})
+
+window.addEventListener('message', (event) => {
+  const msg = event.data as ExtToWebview
+  if (msg?.type === 'load-session') {
+    appProps.filePath = msg.filePath
+    const { entries, parseErrors } = buildEntries(msg.content)
+    appProps.entries = entries
+    appProps.parseErrors = parseErrors
+  }
+})
+
+vscode.postMessage({ type: 'ready' })

--- a/packages/vscode-extension/tsconfig.json
+++ b/packages/vscode-extension/tsconfig.json
@@ -14,5 +14,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/webview/**"]
 }

--- a/packages/vscode-extension/vite.webview.config.ts
+++ b/packages/vscode-extension/vite.webview.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig } from 'vite'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
+import tailwindcss from '@tailwindcss/vite'
+import { resolve } from 'node:path'
+
+/**
+ * Vite config for the VSCode webview bundle.
+ *
+ * Produces a single self-contained JS + CSS bundle that loads inside a
+ * `vscode.WebviewPanel`. Output goes to `dist/webview/` so the extension
+ * (`dist/extension.js`) can resolve assets via `webview.asWebviewUri()`.
+ *
+ * Constraints:
+ * - No code splitting — webview CSP and `asWebviewUri` make multi-chunk loads awkward.
+ * - No filename hashing — the extension references stable paths (`assets/main.js`, `assets/style.css`).
+ * - Minify off in dev for easier devtools inspection (toggle via `--mode production`).
+ */
+export default defineConfig({
+  plugins: [svelte(), tailwindcss()],
+  build: {
+    outDir: resolve(__dirname, 'dist/webview'),
+    emptyOutDir: true,
+    sourcemap: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: resolve(__dirname, 'src/webview/main.svelte.ts'),
+      output: {
+        entryFileNames: 'assets/main.js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: (info) => {
+          if (info.name?.endsWith('.css')) return 'assets/style.css'
+          return 'assets/[name][extname]'
+        },
+        // Disable code splitting — single bundle for webview simplicity.
+        manualChunks: undefined,
+        inlineDynamicImports: true,
+      },
+    },
+  },
+})

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@claude-sessions/core": "workspace:^",
+    "@claude-sessions/ui": "workspace:^",
     "@floating-ui/dom": "^1.7.6",
     "carta-md": "^4.11.2",
     "commander": "^14.0.3",

--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -1,5 +1,8 @@
 @import 'tailwindcss';
 
+/* Scan shared @claude-sessions/ui components so their classes survive purging. */
+@source "../../ui/src/**/*.{svelte,ts}";
+
 /* GitHub Dark theme custom colors */
 @theme {
   --color-gh-bg: #0d1117;

--- a/packages/web/src/lib/components/ExpandableContent.svelte
+++ b/packages/web/src/lib/components/ExpandableContent.svelte
@@ -8,7 +8,6 @@
   let { content, maxLines = 10, lang }: Props = $props()
 
   let expanded = $state(false)
-  let isHovering = $state(false)
 
   const lines = $derived(content.split('\n'))
   const needsExpand = $derived(lines.length > maxLines)
@@ -18,11 +17,7 @@
 </script>
 
 {#if needsExpand}
-  <div
-    class="relative"
-    onmouseenter={() => (isHovering = true)}
-    onmouseleave={() => (isHovering = false)}
-  >
+  <div class="relative group">
     {#if lang}
       <pre
         class="whitespace-pre-wrap font-mono text-xs text-gh-text-secondary overflow-x-auto"><code
@@ -36,14 +31,12 @@
       <div
         class="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-gh-canvas to-transparent pointer-events-none"
       ></div>
-      {#if isHovering}
-        <button
-          class="absolute bottom-1 left-1/2 -translate-x-1/2 px-3 py-1 text-xs bg-gh-border hover:bg-gh-border-muted rounded-full cursor-pointer border-none text-gh-text-secondary transition-all"
-          onclick={() => (expanded = true)}
-        >
-          Click to expand ({lines.length - maxLines} more lines)
-        </button>
-      {/if}
+      <button
+        class="absolute bottom-1 left-1/2 -translate-x-1/2 px-3 py-1 text-xs bg-gh-border hover:bg-gh-border-muted rounded-full cursor-pointer border-none text-gh-text-secondary transition-all opacity-0 group-hover:opacity-100 focus:opacity-100"
+        onclick={() => (expanded = true)}
+      >
+        Click to expand ({lines.length - maxLines} more lines)
+      </button>
     {:else}
       <button
         class="mt-2 px-3 py-1 text-xs bg-gh-border hover:bg-gh-border-muted rounded-full cursor-pointer border-none text-gh-text-secondary"

--- a/packages/web/src/lib/components/IdeTag.stories.svelte
+++ b/packages/web/src/lib/components/IdeTag.stories.svelte
@@ -1,6 +1,8 @@
 <script module>
   import { defineMeta } from '@storybook/addon-svelte-csf'
-  import IdeTag from './IdeTag.svelte'
+  import { IdeTag, SessionContextProvider, createMockSessionContext } from '@claude-sessions/ui'
+
+  const mockCtx = createMockSessionContext()
 
   const { Story } = defineMeta({
     title: 'Components/IdeTag',
@@ -21,9 +23,13 @@
   args={{ tag: 'ide_opened_file', content: 'opened the file /src/lib/utils.ts' }}
 >
   {#snippet children(args)}
-    <div class="p-4 bg-gh-canvas text-gh-text">
-      <IdeTag {...args} />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text">
+          <IdeTag {...args} />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>
 
@@ -32,9 +38,13 @@
   args={{ tag: 'ide_opened_file', content: 'some content without a file path' }}
 >
   {#snippet children(args)}
-    <div class="p-4 bg-gh-canvas text-gh-text">
-      <IdeTag {...args} />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text">
+          <IdeTag {...args} />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>
 
@@ -46,9 +56,13 @@
   }}
 >
   {#snippet children(args)}
-    <div class="p-4 bg-gh-canvas text-gh-text">
-      <IdeTag {...args} />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text">
+          <IdeTag {...args} />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>
 
@@ -57,9 +71,13 @@
   args={{ tag: 'ide_selection', content: 'selected line 42 from /src/routes/+page.svelte' }}
 >
   {#snippet children(args)}
-    <div class="p-4 bg-gh-canvas text-gh-text">
-      <IdeTag {...args} />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text">
+          <IdeTag {...args} />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>
 
@@ -71,9 +89,13 @@
   }}
 >
   {#snippet children(args)}
-    <div class="p-4 bg-gh-canvas text-gh-text">
-      <IdeTag {...args} />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text">
+          <IdeTag {...args} />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>
 
@@ -82,9 +104,13 @@
   args={{ tag: 'ide_opened_file', content: '/packages/core/src/session.ts' }}
 >
   {#snippet children(args)}
-    <div class="p-4 bg-gh-canvas text-gh-text">
-      <IdeTag {...args} />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text">
+          <IdeTag {...args} />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>
 
@@ -94,9 +120,13 @@
   args={{ tag: 'ide_custom_tag', content: 'unexpected IDE tag content here' }}
 >
   {#snippet children(args)}
-    <div class="p-4 bg-gh-canvas text-gh-text">
-      <IdeTag {...args} />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text">
+          <IdeTag {...args} />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>
 
@@ -107,14 +137,18 @@
   }}
 >
   {#snippet children()}
-    <div class="p-4 bg-gh-canvas text-gh-text space-y-3">
-      <IdeTag tag="ide_opened_file" content="opened the file /src/lib/api.ts" />
-      <IdeTag
-        tag="ide_selection"
-        content="selected lines 5 to 15 from /src/lib/components/MessageItem.svelte"
-      />
-      <IdeTag tag="ide_selection" content="const x = computeHash(input)" />
-      <IdeTag tag="ide_unknown" content="some unrecognized tag content" />
-    </div>
+    <SessionContextProvider context={mockCtx}>
+      {#snippet children()}
+        <div class="p-4 bg-gh-canvas text-gh-text space-y-3">
+          <IdeTag tag="ide_opened_file" content="opened the file /src/lib/api.ts" />
+          <IdeTag
+            tag="ide_selection"
+            content="selected lines 5 to 15 from /src/lib/components/MessageItem.svelte"
+          />
+          <IdeTag tag="ide_selection" content="const x = computeHash(input)" />
+          <IdeTag tag="ide_unknown" content="some unrecognized tag content" />
+        </div>
+      {/snippet}
+    </SessionContextProvider>
   {/snippet}
 </Story>

--- a/packages/web/src/lib/components/InputModal.svelte
+++ b/packages/web/src/lib/components/InputModal.svelte
@@ -27,6 +27,7 @@
 
   let inputValue = $state('')
   let inputRef: HTMLInputElement | undefined = $state()
+  const inputId = 'modal-input-' + Math.random().toString(36).slice(2, 9)
 
   $effect(() => {
     if (show) {
@@ -62,9 +63,10 @@
     >
       <h2 class="text-lg font-semibold mb-4">{title}</h2>
       {#if label}
-        <label class="block text-sm text-gh-text-secondary mb-2">{label}</label>
+        <label for={inputId} class="block text-sm text-gh-text-secondary mb-2">{label}</label>
       {/if}
       <input
+        id={inputId}
         bind:this={inputRef}
         bind:value={inputValue}
         type="text"

--- a/packages/web/src/lib/components/MessageItem.svelte
+++ b/packages/web/src/lib/components/MessageItem.svelte
@@ -11,8 +11,8 @@
     parseStopHookSummary,
     parseTurnDuration,
   } from '$lib/utils'
+  import { IdeTag } from '@claude-sessions/ui'
   import ExpandableContent from './ExpandableContent.svelte'
-  import IdeTag from './IdeTag.svelte'
   import TodoItem from './TodoItem.svelte'
   import TooltipButton from './TooltipButton.svelte'
 
@@ -167,10 +167,9 @@
     const content = getMessageContent(msg)
     if (content.trim().length > 0) return true
 
-    // Warn for messages without content (unless it's thinking-only)
-    if (msg.type === 'user' || msg.type === 'human') {
-      const label = isToolResult ? 'Tool result' : 'User message'
-      console.warn(`${label} without content:`, $state.snapshot(msg))
+    // Warn for messages without content (exclude tool_result — empty content is normal)
+    if ((msg.type === 'user' || msg.type === 'human') && !isToolResult) {
+      console.warn('User message without content:', $state.snapshot(msg))
     }
     return false
   })

--- a/packages/web/src/lib/components/MessageList.svelte
+++ b/packages/web/src/lib/components/MessageList.svelte
@@ -36,7 +36,7 @@
     : 'border border-gh-border rounded-lg'}"
 >
   <div class="{enableScroll ? 'overflow-y-auto' : ''} flex-1 p-4 flex flex-col gap-4">
-    {#each messages as msg, i (msg.uuid ? `${msg.uuid}-${i}` : `idx-${i}`)}
+    {#each messages as msg, i (msg.uuid ?? `idx-${i}`)}
       <MessageItem
         {msg}
         {sessionId}

--- a/packages/web/src/lib/components/MessageList.svelte
+++ b/packages/web/src/lib/components/MessageList.svelte
@@ -36,7 +36,7 @@
     : 'border border-gh-border rounded-lg'}"
 >
   <div class="{enableScroll ? 'overflow-y-auto' : ''} flex-1 p-4 flex flex-col gap-4">
-    {#each messages as msg, i (msg.uuid ?? `idx-${i}`)}
+    {#each messages as msg, i (msg.uuid ? `${msg.uuid}-${i}` : `idx-${i}`)}
       <MessageItem
         {msg}
         {sessionId}

--- a/packages/web/src/lib/components/ProjectTree.svelte
+++ b/packages/web/src/lib/components/ProjectTree.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Project, SessionMeta, SessionData } from '$lib/api'
+  import { untrack } from 'svelte'
   import { formatProjectName } from '$lib/utils'
   import {
     sortProjects,
@@ -153,10 +154,20 @@
   )
 
   // Expanded sessions state (for showing summaries, todos, agents sublist)
+  let expandedSessions = $state<Set<string>>(new Set())
+
   // Auto-expand selected session
-  let expandedSessions = $state<Set<string>>(
-    selectedSession ? new Set([selectedSession.id]) : new Set()
-  )
+  $effect(() => {
+    const id = selectedSession?.id
+    if (id) {
+      untrack(() => {
+        if (!expandedSessions.has(id)) {
+          expandedSessions.add(id)
+          expandedSessions = new Set(expandedSessions)
+        }
+      })
+    }
+  })
 
   const toggleSessionExpand = (e: Event, sessionId: string) => {
     e.stopPropagation()

--- a/packages/web/src/lib/components/ScrollButtons.svelte
+++ b/packages/web/src/lib/components/ScrollButtons.svelte
@@ -312,15 +312,17 @@
       </svg>
       <span class="tooltip">{NAV_MODE_CONFIG[navMode].prevLabel}</span>
     </button>
-    <div
-      class="dropdown-wrapper"
-      role="group"
-      bind:this={dropdownRef}
-      onkeydown={handleDropdownKeydown}
-    >
+    <div class="dropdown-wrapper" role="group" bind:this={dropdownRef}>
       <button
         class="nav-btn mode-btn {buttonClass}"
         onclick={toggleDropdown}
+        onkeydown={(e) => {
+          if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+            dropdownOpen = true
+            focusedIndex = e.key === 'ArrowDown' ? 0 : NAV_MODES.length - 1
+            e.preventDefault()
+          }
+        }}
         type="button"
         aria-haspopup="menu"
         aria-expanded={dropdownOpen}
@@ -330,7 +332,13 @@
         <span class="tooltip">Navigate: {NAV_MODE_CONFIG[navMode].label}</span>
       </button>
       {#if dropdownOpen}
-        <div class="dropdown-menu" role="menu" aria-label="Navigation modes">
+        <div
+          class="dropdown-menu"
+          role="menu"
+          aria-label="Navigation modes"
+          tabindex="-1"
+          onkeydown={handleDropdownKeydown}
+        >
           {#each NAV_MODES as mode, i}
             <button
               type="button"

--- a/packages/web/src/lib/components/ValidationDemo.svelte
+++ b/packages/web/src/lib/components/ValidationDemo.svelte
@@ -19,7 +19,11 @@
   let { initialMessages, title = 'Validation Demo' }: Props = $props()
 
   // Convert to Message type and make reactive copy
-  let messages = $state(initialMessages.map((m) => ({ ...m }) as GenericMessage))
+  let messages = $state<GenericMessage[]>([])
+
+  $effect(() => {
+    messages = initialMessages.map((m) => ({ ...m }) as GenericMessage)
+  })
 
   const chainResult = $derived(validateChain(messages))
   const toolResult = $derived(validateToolUseResult(messages))

--- a/packages/web/src/lib/stubs/fs-promises.ts
+++ b/packages/web/src/lib/stubs/fs-promises.ts
@@ -1,0 +1,40 @@
+export const readFile = async () => {
+  throw new Error('readFile not implemented in browser')
+}
+export const writeFile = async () => {
+  throw new Error('writeFile not implemented in browser')
+}
+export const stat = async () => {
+  throw new Error('stat not implemented in browser')
+}
+export const readdir = async () => {
+  throw new Error('readdir not implemented in browser')
+}
+export const access = async () => {
+  throw new Error('access not implemented in browser')
+}
+export const unlink = async () => {
+  throw new Error('unlink not implemented in browser')
+}
+export const mkdir = async () => {
+  throw new Error('mkdir not implemented in browser')
+}
+export const rename = async () => {
+  throw new Error('rename not implemented in browser')
+}
+export const rmdir = async () => {
+  throw new Error('rmdir not implemented in browser')
+}
+
+const defaultExport = {
+  readFile,
+  writeFile,
+  stat,
+  readdir,
+  access,
+  unlink,
+  mkdir,
+  rename,
+  rmdir,
+}
+export default defaultExport

--- a/packages/web/src/lib/stubs/fs.ts
+++ b/packages/web/src/lib/stubs/fs.ts
@@ -1,0 +1,14 @@
+export const readFileSync = () => {
+  throw new Error('readFileSync not implemented in browser')
+}
+export const writeFileSync = () => {
+  throw new Error('writeFileSync not implemented in browser')
+}
+export const existsSync = () => false
+
+const defaultExport = {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+}
+export default defaultExport

--- a/packages/web/src/routes/+layout.svelte
+++ b/packages/web/src/routes/+layout.svelte
@@ -4,12 +4,29 @@
   import { goto } from '$app/navigation'
   import { page } from '$app/state'
   import type { Snippet } from 'svelte'
+  import { provideSessionContext } from '@claude-sessions/ui'
   import * as api from '$lib/api'
   import { appConfig } from '$lib/stores/config'
   import { initTheme, toggleTheme, effectiveTheme, themePreference } from '$lib/stores/theme'
   import { ConfirmModal, Toast } from '$lib/components'
 
   let { children }: { children: Snippet } = $props()
+
+  // Provide @claude-sessions/ui shared components with web-side adapters.
+  // The vscode-extension webview supplies a different provider built on
+  // postMessage RPC; the contract (SessionApi/SessionStorage) is the same.
+  provideSessionContext({
+    api: {
+      openFile: (filePath) => api.openFile(filePath),
+      checkFileExists: (filePath) => api.checkFileExists(filePath),
+    },
+    storage: {
+      get: (key) => (typeof window === 'undefined' ? null : localStorage.getItem(key)),
+      set: (key, value) => {
+        if (typeof window !== 'undefined') localStorage.setItem(key, value)
+      },
+    },
+  })
 
   // Check if we're on a session page for search context
   const isSessionPage = $derived(page.url.pathname.startsWith('/session/'))

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -8,12 +8,24 @@ import { fileURLToPath } from 'node:url'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'))
 
-export default defineConfig({
+export default defineConfig(({ isSsrBuild }) => ({
   plugins: [tailwindcss(), sveltekit()],
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
   },
+  resolve: {
+    alias: {
+      '@claude-sessions/ui/components': resolve(__dirname, '../ui/src/lib/components'),
+      '@claude-sessions/ui': resolve(__dirname, '../ui/src/lib/index.ts'),
+      ...(!isSsrBuild
+        ? {
+            'node:fs/promises': resolve(__dirname, 'src/lib/stubs/fs-promises.ts'),
+            'node:fs': resolve(__dirname, 'src/lib/stubs/fs.ts'),
+          }
+        : {}),
+    },
+  },
   test: {
     exclude: ['e2e/**', 'node_modules/**'],
   },
-})
+}))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,21 @@ importers:
 
   packages/test-fixtures: {}
 
+  packages/ui:
+    devDependencies:
+      '@claude-sessions/core':
+        specifier: workspace:^
+        version: link:../core
+      svelte:
+        specifier: ^5.55.5
+        version: 5.55.5(@typescript-eslint/types@8.59.1)
+      svelte-check:
+        specifier: ^4.4.6
+        version: 4.4.7(picomatch@4.0.4)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/vscode-extension:
     dependencies:
       '@claude-sessions/core':
@@ -115,6 +130,15 @@ importers:
         specifier: ^3.21.2
         version: 3.21.2
     devDependencies:
+      '@claude-sessions/ui':
+        specifier: workspace:^
+        version: link:../ui
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^6.2.4
+        version: 6.2.4(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       '@types/glob':
         specifier: ^9.0.0
         version: 9.0.0
@@ -139,18 +163,33 @@ importers:
       mocha:
         specifier: ^11.7.5
         version: 11.7.5
+      svelte:
+        specifier: ^5.55.5
+        version: 5.55.5(@typescript-eslint/types@8.59.1)
+      svelte-check:
+        specifier: ^4.4.6
+        version: 4.4.7(picomatch@4.0.4)(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
       tsup:
         specifier: ^8.3.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vite:
+        specifier: ^7.3.2
+        version: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/web:
     dependencies:
       '@claude-sessions/core':
         specifier: workspace:^
         version: link:../core
+      '@claude-sessions/ui':
+        specifier: workspace:^
+        version: link:../ui
       '@floating-ui/dom':
         specifier: ^1.7.6
         version: 1.7.6


### PR DESCRIPTION
## Depends on

- #146 — `fix/vscode-remove-inert-stale-calls` (-13/+2) should merge first. Both PRs modify `packages/vscode-extension/src/extension.ts`, and #146 removes the inert `clearSessions({ clearStale, staleProjects })` / `result.deletedStaleProjectCount` / `preview[].isStale` references that currently produce 4 typecheck errors on `main`. After #146 lands, this PR will rebase on `main` to absorb that cleanup; the conflict surface is smaller in this direction than the reverse.

## Summary

**This is a SPIKE PR**, not the full Phase 1 implementation. It de-risks the
Custom Editor migration described in #138 by validating the bundling and
rendering pipeline end-to-end before we commit to the full Phase 1 component
work.

The spike proves three things:

1. A separate Vite build can produce a self-contained Svelte 5 + Tailwind 4
   bundle that fits inside the extension and loads inside a VSCode webview.
2. The CSP we generate (default-src none + nonce-scoped script + asWebviewUri
   styles) is permissive enough for the bundle to execute.
3. The extension <-> webview `postMessage` round-trip works for JSONL content
   (extension reads via `vscode.workspace.fs.readFile`, webview displays the
   first 500 chars + line count).

## What's included

* `vite.webview.config.ts` — separate Vite build emitting a single
  self-contained bundle to `dist/webview/assets/{main.js,style.css}`.
* `src/webview/{main.svelte.ts, App.svelte, app.css}` — minimal Svelte 5
  placeholder rendering the file path, line count, and a snippet.
* `src/sessionEditorProvider.ts` — `CustomReadonlyEditorProvider` with a
  CSP-locked HTML shell and `webview.asWebviewUri` asset loading.
* `src/extension.ts` — registers the provider during `activate()`.
* `package.json` — adds the `customEditors` contribution with
  `priority: "option"` (opt-in via "Open With…", the existing simpleBrowser
  flow stays the default), splits `build` into `build:extension` +
  `build:webview`, adds a `typecheck` script, and pulls in Vite / Svelte /
  Tailwind devDependencies.
* `tsconfig.json` — excludes `src/webview/**` so `tsc` does not try to
  type-check Svelte runes (the Vite plugin owns that pipeline).
* `.vscodeignore` — keeps `vite.webview.config.ts` out of the published vsix.

## What's NOT included (Phase 1 will add)

* The full `SessionViewer` / `MessageList` / `MessageItem` component tree
  (placeholder `App.svelte` will be replaced).
* `vscode.workspace.createFileSystemWatcher` for live reload when the JSONL
  file changes mid-session.
* Mutation support (rename, compress, delete) via `postMessage`.
* Replacing or deprecating the existing web-server flow — this PR makes the
  Custom Editor strictly opt-in.

## Verification

Run from the repo root:

```bash
pnpm --filter @claude-sessions/core build
pnpm --filter claude-sessions build
pnpm --filter claude-sessions package
```

Expected output:

* Extension bundle: `dist/extension.js` (~1.47 MB).
* Webview bundle: `dist/webview/assets/main.js` (~27 KB),
  `dist/webview/assets/style.css` (~8 KB).
* VSIX: `claude-sessions-0.4.7.vsix` (~416 KB) containing both bundles.

## Test Plan

- [x] `pnpm --filter claude-sessions build` produces both extension and
      webview bundles
- [x] `pnpm --filter claude-sessions package` emits a vsix that includes
      `dist/webview/assets/main.js` and `dist/webview/assets/style.css`
- [x] `pnpm --filter claude-sessions typecheck` reports zero errors from the
      spike code (`sessionEditorProvider.ts`, `webview/**`)
- [x] Custom Editor activation test (`webview.test.ts` → `Custom Editor activates for .jsonl files`): `vscode.openWith` opens a tab whose `TabInputCustom.viewType === 'claudeSessions.jsonlPreview'`. Full Svelte render verification still deferred to Phase 1 alongside SessionViewer integration.

## Notes for reviewers

* `priority: "option"` means VSCode will not surface the Custom Editor as the
  default for `*.jsonl`. Users opt in with right-click → "Open With…" →
  "Claude Session Preview".
* The webview placeholder intentionally uses Tailwind utilities so reviewers
  can confirm Tailwind 4 styles arrive intact under the CSP.
* `pnpm --filter claude-sessions typecheck` reports pre-existing baseline
  errors in `treeProvider.ts` (originating from `origin/main`, unchanged by
  this PR). They will need a separate cleanup PR before Phase 1 can land
  cleanly through the existing pre-push hook.

Relates to #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSONL session preview custom editor in VS Code with open/preview-to-side commands and restart-extension-host action
  * New Svelte webview UI for session timelines
  * Published UI workspace package and session-context API with a mock helper

* **Refactor**
  * UI components migrated to use session context
  * Extension build split into separate extension and webview builds
  * "Open terminal" now opens an integrated terminal

* **Tests**
  * Added session cleanup/stale-project tests and webview/command registration tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


