### PR TITLE
chore(core): widen AgentInfo inferred type to unblock vscode typecheck

### DIFF
--- a/packages/core/src/session/tree.ts
+++ b/packages/core/src/session/tree.ts
@@ -234,15 +234,17 @@ const loadSessionTreeDataInternal = (
             }
           }
 
-          return {
+          const info: AgentInfo = {
             id: agentId,
             name: agentName,
             messageCount: agentUserAssistant.length,
-          } satisfies AgentInfo
+          }
+          return info
         }).pipe(
           Effect.catchAll((error) => {
             log.debug(`Agent file not readable: ${agentId}`, error)
-            return Effect.succeed({ id: agentId, messageCount: 0 } satisfies AgentInfo)
+            const fallback: AgentInfo = { id: agentId, messageCount: 0 }
+            return Effect.succeed(fallback)
           })
         )
       },


### PR DESCRIPTION
## Summary

Pure type-only fix in `packages/core/src/session/tree.ts` that restores
`agents: AgentInfo[]` in the public type signature of `loadSessionTreeData`.
Without this change, the inferred return type contained a union — one variant
with `name`, one without — causing downstream consumers (such as
`packages/vscode-extension/src/treeProvider.ts:651`) to fail typecheck on
`agent.name`. No runtime behavior change.

This is a precursor to enabling `tsc --noEmit` for the VSCode extension
package, which is blocked today by this single propagated type.

## Why

`loadSessionTreeDataInternal` builds the agents array via `Effect.forEach`.
Each iteration returns either:

* the success branch — an object with `id`, `name: string | undefined`,
  `messageCount`
* the `Effect.catchAll` fallback — an object with `id`, `messageCount`
  (no `name`)

Both branches used `satisfies AgentInfo`. `satisfies` only validates
assignability — it does **not** widen the inferred type. So TypeScript
inferred the literal union, and `Effect.gen` propagated the union all the
way out to the public signature:

```ts
declare const loadSessionTreeData: (...) => Effect.Effect<{
  ...
  agents: ({ id: string; name: string | undefined; messageCount: number }
         | { id: string; messageCount: number })[];
  ...
}, ...>
```

Reading `.name` on the union element fails because the second variant has
no `name` property.

Annotating each return value as `AgentInfo` (instead of `satisfies`) widens
the inferred type at the source, so the public type becomes
`agents: AgentInfo[]` and downstream consumers get back the optional `name`.

## Changes

* `packages/core/src/session/tree.ts` — replace `satisfies AgentInfo` with
  `const info: AgentInfo = ...; return info` on both the success and
  fallback branches inside `loadSessionTreeDataInternal`.

That is the entire diff (5 insertions, 3 deletions, single file).

## Scope notes

PR #143 noted other typecheck errors in the VSCode extension package. After
this fix, `treeProvider.ts` is clean. There are still other unrelated
typecheck errors in `extension.ts` (a duplicate `env` literal property and
calls to `previewCleanup` / `clearSessions` that reference fields the
implementations do not produce). Those are real bugs, not generic
propagation issues, and need their own follow-up. They are intentionally
left out of this PR to keep scope minimal.

The pre-push hook (`pnpm build && pnpm typecheck && pnpm test`) passes
without `--no-verify` because `vscode-extension` does not currently have a
`typecheck` script registered, so `pnpm -r typecheck` skips it. Adding the
`typecheck` script for that package can be a follow-up PR once the
remaining `extension.ts` errors are fixed.

## Test Plan

- [x] `pnpm typecheck` — 0 errors across core, mcp, web
- [x] `pnpm build` — all packages build successfully
- [x] `pnpm --filter @claude-sessions/core test` — 420 tests passing
- [x] `pnpm --filter claude-sessions test` — 17 VSCode extension tests passing
- [x] `pnpm --filter @claude-sessions/web test` — 83 web tests passing
- [x] Pre-push hook passed without `--no-verify`
- [x] Generated `dist/index.d.ts` shows `agents: AgentInfo[]` (was
      `agents: ({...with name...} | {...without name...})[]`)

Relates to #138