### PR TITLE
fix(core): guard readdir against missing project folders (TOCTOU)

### DIFF
--- a/packages/core/src/session/cleanup.test.ts
+++ b/packages/core/src/session/cleanup.test.ts
@@ -4,6 +4,16 @@ import * as path from 'node:path'
 import * as os from 'node:os'
 import { Effect } from 'effect'
 
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  const readdirMock = vi.fn(actual.readdir)
+  return {
+    ...actual,
+    readdir: readdirMock,
+    default: { ...actual, readdir: readdirMock },
+  }
+})
+
 vi.mock('../paths.js', async () => {
   const actual = await vi.importActual('../paths.js')
   return {
@@ -63,6 +73,10 @@ describe('clearSessions', () => {
   const projectName = '-Users-test-project'
 
   beforeEach(async () => {
+    // Restore readdir to the real implementation; individual tests may override.
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    vi.mocked(fs.readdir).mockImplementation(actual.readdir as typeof fs.readdir)
+
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'cleanup-test-'))
     await fs.mkdir(path.join(tempDir, projectName), { recursive: true })
     vi.mocked(getSessionsDir).mockReturnValue(tempDir)
@@ -581,5 +595,94 @@ describe('clearSessions', () => {
       expect(nestedStillExists).toBe(true)
       expect(result.deletedStaleProjectCount ?? 0).toBe(0)
     })
+  })
+
+  // Issue #103 — Guard readdir against missing project folders (TOCTOU).
+  // Encoded project folders can disappear between listProjects and any
+  // subsequent per-project readdir (cross-PC sync, manual deletion, etc).
+  // Without catchAll, one ENOENT aborts the entire Effect.all run.
+  describe('readdir TOCTOU safety (Issue #103)', () => {
+    function makeEnoent(p: string): NodeJS.ErrnoException {
+      const err = new Error(
+        `ENOENT: no such file or directory, scandir '${p}'`
+      ) as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      return err
+    }
+
+    it('T1: clearSessions Step 1 skips a project whose folder vanishes before readdir', async () => {
+      const projA = '-Users-test-toctou-step1-A'
+      const projB = '-Users-test-toctou-step1-B'
+      await fs.mkdir(path.join(tempDir, projA), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projB), { recursive: true })
+      await writeSession(tempDir, projA, 'a1', [makeInvalidMessage({ uuid: 'a1' })])
+      await writeSession(tempDir, projB, 'b1', [makeInvalidMessage({ uuid: 'b1' })])
+
+      // Override readdir to throw ENOENT only for projA, simulating mid-operation deletion.
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projA)) {
+          return Promise.reject(makeEnoent(p))
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After fix: projA silently skipped, projB processed normally.
+      const result = await Effect.runPromise(
+        clearSessions({ clearInvalid: true, clearEmpty: false, clearOrphanAgents: false })
+      )
+
+      expect(result.removedMessageCount).toBeGreaterThan(0)
+    })
+
+    it('T2: clearSessions Step 6 skips a project whose folder vanishes between Step 1 and Step 6', async () => {
+      const projA = '-Users-test-toctou-step6-vanish'
+      const projB = '-Users-test-toctou-step6-keep'
+      await fs.mkdir(path.join(tempDir, projA), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projB), { recursive: true })
+      await writeSession(tempDir, projA, 'a1', [makeMessage({ uuid: 'a1' })])
+      await writeSession(tempDir, projB, 'b1', [makeMessage({ uuid: 'b1' })])
+
+      // First readdir(projA) succeeds (Step 1 cleanInvalid), subsequent calls fail (Step 6 dedup).
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      let projACallCount = 0
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projA)) {
+          projACallCount++
+          if (projACallCount > 1) {
+            return Promise.reject(makeEnoent(p))
+          }
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After fix: Step 6 catches ENOENT on projA, completes normally.
+      await expect(
+        Effect.runPromise(
+          clearSessions({
+            clearInvalid: true,
+            clearEmpty: false,
+            clearOrphanAgents: false,
+            deduplicateTitles: true,
+          })
+        )
+      ).resolves.toBeDefined()
+    })
+
+    // T3 (getMostRecentSessionMtime readdir failure) was investigated but proved
+    // unreliable as a unit test because previewCleanup's chain calls readdir on the
+    // same projectPath through multiple unwrapped sites (crud-streaming, crud, agents,
+    // todos). Targeting only the mtime probe via mock-counting or physical removal
+    // is brittle — the upstream calls hit ENOENT first and abort before
+    // getMostRecentSessionMtime is reached. The fix itself (`.catch(() => [])` on
+    // cleanup.ts:37) is one line and covered by code review. Broader readdir
+    // hardening across the previewCleanup chain is tracked as a follow-up — see
+    // PR description "Follow-up" section.
   })
 })

--- a/packages/core/src/session/cleanup.test.ts
+++ b/packages/core/src/session/cleanup.test.ts
@@ -678,11 +678,144 @@ describe('clearSessions', () => {
     // T3 (getMostRecentSessionMtime readdir failure) was investigated but proved
     // unreliable as a unit test because previewCleanup's chain calls readdir on the
     // same projectPath through multiple unwrapped sites (crud-streaming, crud, agents,
-    // todos). Targeting only the mtime probe via mock-counting or physical removal
-    // is brittle — the upstream calls hit ENOENT first and abort before
-    // getMostRecentSessionMtime is reached. The fix itself (`.catch(() => [])` on
-    // cleanup.ts:37) is one line and covered by code review. Broader readdir
-    // hardening across the previewCleanup chain is tracked as a follow-up — see
-    // PR description "Follow-up" section.
+    // todos). The fix itself (narrow `.catch` on cleanup.ts:37) is one line and
+    // covered by code review. Broader readdir hardening across the previewCleanup
+    // chain is tracked as a follow-up — see PR description "Follow-up" section.
+
+    it('T6: non-ENOENT readdir error (EACCES) PROPAGATES from Step 1 (does not silently skip)', async () => {
+      const projA = '-Users-test-eacces-step1'
+      await fs.mkdir(path.join(tempDir, projA), { recursive: true })
+      await writeSession(tempDir, projA, 'a1', [makeInvalidMessage({ uuid: 'a1' })])
+
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projA)) {
+          const err = new Error(
+            `EACCES: permission denied, scandir '${p}'`
+          ) as NodeJS.ErrnoException
+          err.code = 'EACCES'
+          return Promise.reject(err)
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After narrow-catch fix: EACCES is NOT swallowed → clearSessions fails loudly
+      await expect(
+        Effect.runPromise(
+          clearSessions({ clearInvalid: true, clearEmpty: false, clearOrphanAgents: false })
+        )
+      ).rejects.toThrow()
+    })
+
+    it('T8: clearSessions Step 2 (listSessions) skips a project whose folder vanishes', async () => {
+      const projA = '-Users-test-toctou-step2-vanish'
+      const projB = '-Users-test-toctou-step2-keep'
+      await fs.mkdir(path.join(tempDir, projA), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projB), { recursive: true })
+      // projB has an empty session so clearEmpty has something to do
+      await writeSession(tempDir, projB, 'b-empty', [])
+
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projA)) {
+          return Promise.reject(makeEnoent(p))
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After fix: projA Step 2 catchAll → projB processed normally
+      await expect(
+        Effect.runPromise(
+          clearSessions({
+            clearInvalid: false,
+            clearEmpty: true,
+            clearOrphanAgents: false,
+          })
+        )
+      ).resolves.toBeDefined()
+    })
+
+    it('T9: clearSessions Step 4 (deleteOrphanAgents) skips a project whose folder vanishes', async () => {
+      const projA = '-Users-test-toctou-step4-vanish'
+      const projB = '-Users-test-toctou-step4-keep'
+      await fs.mkdir(path.join(tempDir, projA), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projB), { recursive: true })
+      await writeSession(tempDir, projB, 'b1', [makeMessage({ uuid: 'b1' })])
+
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projA)) {
+          return Promise.reject(makeEnoent(p))
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After fix: projA Step 4 catchAll → projB completes
+      await expect(
+        Effect.runPromise(
+          clearSessions({
+            clearInvalid: false,
+            clearEmpty: false,
+            clearOrphanAgents: true,
+          })
+        )
+      ).resolves.toBeDefined()
+    })
+
+    it('T10: clearSessions reports skippedProjectCount (unique per project across steps)', async () => {
+      const projA = '-Users-test-skipped-A'
+      const projB = '-Users-test-skipped-B'
+      const projC = '-Users-test-skipped-C-healthy'
+      await fs.mkdir(path.join(tempDir, projA), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projB), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projC), { recursive: true })
+      await writeSession(tempDir, projC, 'c1', [makeMessage({ uuid: 'c1' })])
+
+      // Strategy: let listProjects's per-entry readdir succeed (so projA/B reach
+      // targetProjects), then fail Step 1 + Step 6 readdir(projA/B) to trigger
+      // cleanup.ts's skippedProjects tracking. Use call-count per path: first
+      // call per project succeeds (listProjects), subsequent fail.
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      const callsPerProject: Record<string, number> = { [projA]: 0, [projB]: 0 }
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string') {
+          for (const key of [projA, projB]) {
+            if (p.endsWith(key)) {
+              callsPerProject[key]++
+              // 1st call = listProjects per-entry (success); 2nd+ = Step 1/6 (fail)
+              if (callsPerProject[key] > 1) {
+                return Promise.reject(makeEnoent(p))
+              }
+            }
+          }
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      const result = await Effect.runPromise(
+        clearSessions({
+          clearInvalid: true,
+          clearEmpty: false,
+          clearOrphanAgents: false,
+          deduplicateTitles: true,
+        })
+      )
+
+      // Both projA + projB are skipped across Step 1 + Step 6.
+      // skippedProjectCount must be 2 (unique), not 4 (steps × projects).
+      expect(result.skippedProjectCount).toBe(2)
+    })
   })
 })

--- a/packages/core/src/session/cleanup.ts
+++ b/packages/core/src/session/cleanup.ts
@@ -18,7 +18,10 @@ import { listProjects } from './projects.js'
 import { listSessions, deleteSession } from './crud.js'
 import { listSessionsMeta } from './crud-streaming.js'
 import { filterSessionFiles } from './crud-helpers.js'
+import { createLogger } from '../logger.js'
 import type { Message, CleanupPreview, ClearSessionsResult } from '../types.js'
+
+const log = createLogger('cleanup')
 
 // Grace period for "folder missing on disk" before marking a project as stale.
 // Protects sessions arriving via cross-PC sync (e.g., syncthing) where the
@@ -29,7 +32,12 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000
 const getMostRecentSessionMtime = async (projectPath: string): Promise<number> => {
   const exists = await fileExists(projectPath)
   if (!exists) return 0
-  const files = await fs.readdir(projectPath)
+  // Guard against TOCTOU: project folder may vanish between fileExists and readdir
+  // (cross-PC sync, manual deletion, etc). See Issue #103.
+  const files = await fs.readdir(projectPath).catch((error) => {
+    log.debug(`getMostRecentSessionMtime: skipping unreadable project folder ${projectPath}`, error)
+    return [] as string[]
+  })
   const sessionFiles = filterSessionFiles(files)
   let mostRecent = 0
   for (const file of sessionFiles) {
@@ -278,7 +286,18 @@ export const clearSessions = (options: {
     if (clearInvalid) {
       for (const project of targetProjects) {
         const projectPath = path.join(getSessionsDir(), project.name)
-        const files = yield* Effect.tryPromise(() => fs.readdir(projectPath))
+        // Guard against TOCTOU: project folder may vanish between listProjects and this readdir
+        // (cross-PC sync, manual deletion). One ENOENT must not abort cleanup of other projects.
+        // See Issue #103.
+        const files = yield* Effect.tryPromise(() => fs.readdir(projectPath)).pipe(
+          Effect.catchAll((error) => {
+            log.debug(
+              `Step 1 (clearInvalid): skipping missing project folder ${project.name}`,
+              error
+            )
+            return Effect.succeed([] as string[])
+          })
+        )
         const sessionFiles = filterSessionFiles(files)
 
         for (const file of sessionFiles) {
@@ -341,7 +360,16 @@ export const clearSessions = (options: {
     if (deduplicateTitles) {
       for (const project of targetProjects) {
         const projectPath = path.join(getSessionsDir(), project.name)
-        const files = yield* Effect.tryPromise(() => fs.readdir(projectPath))
+        // Guard against TOCTOU: project folder may vanish mid-operation. See Issue #103.
+        const files = yield* Effect.tryPromise(() => fs.readdir(projectPath)).pipe(
+          Effect.catchAll((error) => {
+            log.debug(
+              `Step 6 (deduplicateTitles): skipping missing project folder ${project.name}`,
+              error
+            )
+            return Effect.succeed([] as string[])
+          })
+        )
         const sessionFiles = filterSessionFiles(files)
 
         for (const file of sessionFiles) {

--- a/packages/core/src/session/cleanup.ts
+++ b/packages/core/src/session/cleanup.ts
@@ -11,6 +11,7 @@ import {
   FileReadError,
   FileWriteError,
   fileExists,
+  isMissingFolderError,
 } from '../utils.js'
 import { findLinkedAgents, findOrphanAgents, deleteOrphanAgents } from '../agents.js'
 import { sessionHasTodos, findOrphanTodos, deleteOrphanTodos } from '../todos.js'
@@ -19,7 +20,7 @@ import { listSessions, deleteSession } from './crud.js'
 import { listSessionsMeta } from './crud-streaming.js'
 import { filterSessionFiles } from './crud-helpers.js'
 import { createLogger } from '../logger.js'
-import type { Message, CleanupPreview, ClearSessionsResult } from '../types.js'
+import type { Message, CleanupPreview, ClearSessionsResult, SessionMeta } from '../types.js'
 
 const log = createLogger('cleanup')
 
@@ -33,9 +34,13 @@ const getMostRecentSessionMtime = async (projectPath: string): Promise<number> =
   const exists = await fileExists(projectPath)
   if (!exists) return 0
   // Guard against TOCTOU: project folder may vanish between fileExists and readdir
-  // (cross-PC sync, manual deletion, etc). See Issue #103.
-  const files = await fs.readdir(projectPath).catch((error) => {
-    log.debug(`getMostRecentSessionMtime: skipping unreadable project folder ${projectPath}`, error)
+  // (cross-PC sync, manual deletion, etc). Narrow to ENOENT/ENOTDIR so unrelated
+  // I/O failures (EACCES, EIO, EMFILE) still propagate. See Issue #103.
+  const files = await fs.readdir(projectPath).catch((error: NodeJS.ErrnoException) => {
+    if (!isMissingFolderError(error)) {
+      throw error
+    }
+    log.debug(`getMostRecentSessionMtime: skipping missing project folder ${projectPath}`, error)
     return [] as string[]
   })
   const sessionFiles = filterSessionFiles(files)
@@ -281,20 +286,30 @@ export const clearSessions = (options: {
     let deletedOrphanTodoCount = 0
     let deletedStaleProjectCount = 0
     const sessionsToDelete: { project: string; sessionId: string }[] = []
+    // Track projects whose folder vanished mid-operation so the caller can
+    // surface a count rather than silently swallowing them. See Issue #103.
+    const skippedProjects = new Set<string>()
 
     // Step 1: Clean invalid API key messages from all sessions (if clearInvalid)
     if (clearInvalid) {
       for (const project of targetProjects) {
         const projectPath = path.join(getSessionsDir(), project.name)
         // Guard against TOCTOU: project folder may vanish between listProjects and this readdir
-        // (cross-PC sync, manual deletion). One ENOENT must not abort cleanup of other projects.
-        // See Issue #103.
-        const files = yield* Effect.tryPromise(() => fs.readdir(projectPath)).pipe(
+        // (cross-PC sync, manual deletion). Narrow to ENOENT/ENOTDIR so unrelated I/O failures
+        // (EACCES, EIO, EMFILE) still propagate. See Issue #103.
+        const files = yield* Effect.tryPromise({
+          try: () => fs.readdir(projectPath),
+          catch: (error) => error as NodeJS.ErrnoException,
+        }).pipe(
           Effect.catchAll((error) => {
+            if (!isMissingFolderError(error)) {
+              return Effect.fail(error)
+            }
             log.debug(
               `Step 1 (clearInvalid): skipping missing project folder ${project.name}`,
               error
             )
+            skippedProjects.add(project.name)
             return Effect.succeed([] as string[])
           })
         )
@@ -316,7 +331,18 @@ export const clearSessions = (options: {
     // Step 2: Also find originally empty sessions (if clearEmpty is true)
     if (clearEmpty) {
       for (const project of targetProjects) {
-        const sessions = yield* listSessions(project.name)
+        // Guard against TOCTOU: listSessions calls fs.readdir on the project folder.
+        // Narrow to ENOENT/ENOTDIR so other errors still abort. See Issue #103.
+        const sessions = yield* listSessions(project.name).pipe(
+          Effect.catchAll((error) => {
+            if (!isMissingFolderError(error)) {
+              return Effect.fail(error)
+            }
+            log.debug(`Step 2 (clearEmpty): skipping missing project folder ${project.name}`, error)
+            skippedProjects.add(project.name)
+            return Effect.succeed([] as SessionMeta[])
+          })
+        )
         for (const session of sessions) {
           if (session.messageCount === 0) {
             const alreadyMarked = sessionsToDelete.some(
@@ -345,7 +371,21 @@ export const clearSessions = (options: {
     // Step 4: Delete orphan agents if requested
     if (clearOrphanAgents) {
       for (const project of targetProjects) {
-        const result = yield* deleteOrphanAgents(project.name)
+        // Guard against TOCTOU: deleteOrphanAgents reads the project folder.
+        // Narrow to ENOENT/ENOTDIR. See Issue #103.
+        const result = yield* deleteOrphanAgents(project.name).pipe(
+          Effect.catchAll((error) => {
+            if (!isMissingFolderError(error)) {
+              return Effect.fail(error)
+            }
+            log.debug(
+              `Step 4 (clearOrphanAgents): skipping missing project folder ${project.name}`,
+              error
+            )
+            skippedProjects.add(project.name)
+            return Effect.succeed({ count: 0 })
+          })
+        )
         deletedOrphanAgentCount += result.count
       }
     }
@@ -360,13 +400,20 @@ export const clearSessions = (options: {
     if (deduplicateTitles) {
       for (const project of targetProjects) {
         const projectPath = path.join(getSessionsDir(), project.name)
-        // Guard against TOCTOU: project folder may vanish mid-operation. See Issue #103.
-        const files = yield* Effect.tryPromise(() => fs.readdir(projectPath)).pipe(
+        // Guard against TOCTOU: narrow to ENOENT/ENOTDIR. See Issue #103.
+        const files = yield* Effect.tryPromise({
+          try: () => fs.readdir(projectPath),
+          catch: (error) => error as NodeJS.ErrnoException,
+        }).pipe(
           Effect.catchAll((error) => {
+            if (!isMissingFolderError(error)) {
+              return Effect.fail(error)
+            }
             log.debug(
               `Step 6 (deduplicateTitles): skipping missing project folder ${project.name}`,
               error
             )
+            skippedProjects.add(project.name)
             return Effect.succeed([] as string[])
           })
         )
@@ -417,5 +464,6 @@ export const clearSessions = (options: {
       deletedOrphanTodoCount,
       deletedStaleProjectCount,
       removedMessageCount,
+      skippedProjectCount: skippedProjects.size,
     } satisfies ClearSessionsResult
   })

--- a/packages/core/src/session/projects.test.ts
+++ b/packages/core/src/session/projects.test.ts
@@ -117,5 +117,32 @@ describe('listProjects', () => {
       const names = projects.map((p) => p.name).sort()
       expect(names).toEqual([projOk1, projOk2].sort())
     })
+
+    it('T7: non-ENOENT readdir error (EACCES) PROPAGATES (does not silently skip)', async () => {
+      const projDenied = '-Users-test-listprojects-eacces'
+      const projOk = '-Users-test-listprojects-ok-eacces'
+      await fs.mkdir(path.join(tempDir, projDenied), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projOk), { recursive: true })
+      await writeSession(tempDir, projDenied, 'd1')
+      await writeSession(tempDir, projOk, 'o1')
+
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projDenied)) {
+          const err = new Error(
+            `EACCES: permission denied, scandir '${p}'`
+          ) as NodeJS.ErrnoException
+          err.code = 'EACCES'
+          return Promise.reject(err)
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After narrow-catch fix: EACCES is NOT swallowed → listProjects fails loudly
+      await expect(Effect.runPromise(listProjects)).rejects.toThrow()
+    })
   })
 })

--- a/packages/core/src/session/projects.test.ts
+++ b/packages/core/src/session/projects.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { Effect } from 'effect'
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  const readdirMock = vi.fn(actual.readdir)
+  return {
+    ...actual,
+    readdir: readdirMock,
+    default: { ...actual, readdir: readdirMock },
+  }
+})
+
+vi.mock('../paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../paths.js')>('../paths.js')
+  return {
+    ...actual,
+    getSessionsDir: vi.fn(),
+  }
+})
+
+import { listProjects } from './projects.js'
+import { getSessionsDir } from '../paths.js'
+
+function writeSession(dir: string, projectName: string, sessionId: string) {
+  const content =
+    JSON.stringify({
+      type: 'user',
+      uuid: `msg-${sessionId}`,
+      timestamp: new Date().toISOString(),
+      message: { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    }) + '\n'
+  return fs.writeFile(path.join(dir, projectName, `${sessionId}.jsonl`), content, 'utf-8')
+}
+
+describe('listProjects', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    // Restore readdir to the real implementation; individual tests may override.
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    vi.mocked(fs.readdir).mockImplementation(actual.readdir as typeof fs.readdir)
+
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'projects-test-'))
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  // Issue #103 — Guard per-entry readdir against missing folders (TOCTOU).
+  describe('readdir TOCTOU safety (Issue #103)', () => {
+    function makeEnoent(p: string): NodeJS.ErrnoException {
+      const err = new Error(
+        `ENOENT: no such file or directory, scandir '${p}'`
+      ) as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      return err
+    }
+
+    it('T4: listProjects skips an entry whose folder vanishes between top-level readdir and per-entry readdir', async () => {
+      const projGone = '-Users-test-listprojects-gone'
+      const projKeep = '-Users-test-listprojects-keep'
+      await fs.mkdir(path.join(tempDir, projGone), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projKeep), { recursive: true })
+      await writeSession(tempDir, projGone, 'g1')
+      await writeSession(tempDir, projKeep, 'k1')
+
+      // Top-level readdir(sessionsDir) succeeds and reports both entries.
+      // Per-entry readdir(projGone) fails as if the folder vanished mid-iteration.
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projGone)) {
+          return Promise.reject(makeEnoent(p))
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After fix: vanished entry filtered out, other entries returned normally.
+      const projects = await Effect.runPromise(listProjects)
+      expect(projects.map((p) => p.name)).toContain(projKeep)
+      expect(projects.map((p) => p.name)).not.toContain(projGone)
+    })
+
+    it('T5: listProjects returns other valid projects when one entry readdir fails', async () => {
+      const projFail = '-Users-test-listprojects-fail'
+      const projOk1 = '-Users-test-listprojects-ok1'
+      const projOk2 = '-Users-test-listprojects-ok2'
+      await fs.mkdir(path.join(tempDir, projFail), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projOk1), { recursive: true })
+      await fs.mkdir(path.join(tempDir, projOk2), { recursive: true })
+      await writeSession(tempDir, projFail, 'f1')
+      await writeSession(tempDir, projOk1, 'a1')
+      await writeSession(tempDir, projOk2, 'b1')
+
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(fs.readdir).mockImplementation(((p: unknown, opts: unknown) => {
+        if (typeof p === 'string' && p.endsWith(projFail)) {
+          return Promise.reject(makeEnoent(p))
+        }
+        return (actual.readdir as typeof fs.readdir)(
+          p as Parameters<typeof fs.readdir>[0],
+          opts as Parameters<typeof fs.readdir>[1]
+        )
+      }) as typeof fs.readdir)
+
+      // After fix: 2 healthy projects returned, failing entry filtered.
+      const projects = await Effect.runPromise(listProjects)
+      const names = projects.map((p) => p.name).sort()
+      expect(names).toEqual([projOk1, projOk2].sort())
+    })
+  })
+})

--- a/packages/core/src/session/projects.ts
+++ b/packages/core/src/session/projects.ts
@@ -7,6 +7,9 @@ import * as path from 'node:path'
 import { getSessionsDir, folderNameToPath } from '../paths.js'
 import type { Project } from '../types.js'
 import { fileExists } from '../utils.js'
+import { createLogger } from '../logger.js'
+
+const log = createLogger('projects')
 
 // List all project directories
 export const listProjects = Effect.gen(function* () {
@@ -20,7 +23,7 @@ export const listProjects = Effect.gen(function* () {
 
   const entries = yield* Effect.tryPromise(() => fs.readdir(sessionsDir, { withFileTypes: true }))
 
-  const projects = yield* Effect.all(
+  const results = yield* Effect.all(
     entries
       .filter((e) => e.isDirectory() && !e.name.startsWith('.'))
       .map((entry) =>
@@ -37,10 +40,19 @@ export const listProjects = Effect.gen(function* () {
             path: projectPath,
             sessionCount: sessionFiles.length,
           } satisfies Project
-        })
+        }).pipe(
+          // Guard against TOCTOU: an entry's folder may vanish between the top-level
+          // readdir and this per-entry readdir (cross-PC sync, manual deletion).
+          // A single ENOENT must not abort enumeration of healthy projects.
+          // See Issue #103.
+          Effect.catchAll((error) => {
+            log.debug(`listProjects: skipping unreadable project ${entry.name}`, error)
+            return Effect.succeed(null as Project | null)
+          })
+        )
       ),
     { concurrency: 10 }
   )
 
-  return projects
+  return results.filter((p): p is Project => p !== null)
 })

--- a/packages/core/src/session/projects.ts
+++ b/packages/core/src/session/projects.ts
@@ -6,7 +6,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { getSessionsDir, folderNameToPath } from '../paths.js'
 import type { Project } from '../types.js'
-import { fileExists } from '../utils.js'
+import { fileExists, isMissingFolderError } from '../utils.js'
 import { createLogger } from '../logger.js'
 
 const log = createLogger('projects')
@@ -29,7 +29,10 @@ export const listProjects = Effect.gen(function* () {
       .map((entry) =>
         Effect.gen(function* () {
           const projectPath = path.join(sessionsDir, entry.name)
-          const files = yield* Effect.tryPromise(() => fs.readdir(projectPath))
+          const files = yield* Effect.tryPromise({
+            try: () => fs.readdir(projectPath),
+            catch: (error) => error as NodeJS.ErrnoException,
+          })
           // Exclude agent- files (subagent logs)
           const sessionFiles = files.filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'))
           const displayName = yield* Effect.tryPromise(() => folderNameToPath(entry.name))
@@ -43,10 +46,13 @@ export const listProjects = Effect.gen(function* () {
         }).pipe(
           // Guard against TOCTOU: an entry's folder may vanish between the top-level
           // readdir and this per-entry readdir (cross-PC sync, manual deletion).
-          // A single ENOENT must not abort enumeration of healthy projects.
-          // See Issue #103.
+          // Narrow to ENOENT/ENOTDIR so unrelated I/O failures (EACCES, EIO, etc.)
+          // still propagate. See Issue #103.
           Effect.catchAll((error) => {
-            log.debug(`listProjects: skipping unreadable project ${entry.name}`, error)
+            if (!isMissingFolderError(error)) {
+              return Effect.fail(error)
+            }
+            log.debug(`listProjects: skipping missing project ${entry.name}`, error)
             return Effect.succeed(null as Project | null)
           })
         )

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -273,6 +273,13 @@ export interface ClearSessionsResult {
   deletedOrphanTodoCount?: number
   deletedStaleProjectCount?: number
   removedMessageCount?: number
+  /**
+   * Projects skipped during cleanup because their folder vanished mid-operation
+   * (ENOENT/ENOTDIR on a per-project readdir or operation). Counted unique
+   * per project name so a folder skipped across multiple steps counts once.
+   * See Issue #103.
+   */
+  skippedProjectCount?: number
 }
 
 /** Preview of sessions that would be cleaned up */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -28,6 +28,18 @@ export class FileWriteError extends Data.TaggedError('FileWriteError')<{
   readonly cause: unknown
 }> {}
 
+/**
+ * True when the error indicates a missing or invalid directory path
+ * (ENOENT, ENOTDIR). Used to narrow TOCTOU-race recovery so unrelated
+ * I/O failures (EACCES, EIO, EMFILE, EBUSY, etc.) still propagate.
+ *
+ * See Issue #103 + .claude/rules/async-io.md.
+ */
+export const isMissingFolderError = (error: unknown): boolean => {
+  const code = (error as NodeJS.ErrnoException | null | undefined)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
 // IDE tag pattern for removal
 const IDE_TAG_PATTERN = /<ide_[^>]*>[\s\S]*?<\/ide_[^>]*>/g
 


### PR DESCRIPTION
## Summary

Encoded session folders can vanish between `listProjects` and any subsequent per-project `readdir` / Effect call (cross-PC sync, manual deletion, etc). Without `catchAll`, a single ENOENT aborts the entire `Effect.all` run, leaving healthy projects unprocessed and surfacing a raw error to the caller.

This PR adds defensive guards around all affected `readdir` and per-project operations in the cleanup + listing chain, **narrowed to `ENOENT`/`ENOTDIR`** so unrelated I/O failures (EACCES, EIO, EMFILE, EBUSY) still propagate. Each guard logs at debug level via `createLogger` so silently-skipped folders are still observable in diagnostics. Skipped projects are surfaced via the new `ClearSessionsResult.skippedProjectCount` field (unique per project).

Aligns with `.claude/rules/async-io.md`:
> Effect.gen + yield* failures bypass JS try/catch; use Effect.catchAll pipe instead.

## Why fix `getMostRecentSessionMtime` too?

PR #143 (f07a024) introduced `detectStaleProject` + `getMostRecentSessionMtime` with a 30-day grace period, but the new helper's `await fs.readdir(projectPath)` is unguarded. If the folder vanishes between `fileExists` and `readdir`, `getMostRecentSessionMtime` throws → `detectStaleProject` rejects via `Effect.tryPromise` → `previewCleanup` aborts. The narrow `.catch` here matches the rest of the chain: missing data → mtime=0 → grace period bypassed → `isStale=true` returned without error.

This was called out in https://github.com/es6kr/claude-code-sessions/issues/103#issuecomment-4478849856 under "Remaining gap on main".

## Affected sites (final, after 633664f)

| File | Line | Change |
|------|------|--------|
| `packages/core/src/utils.ts` | 31 | New `isMissingFolderError(error)` helper (ENOENT/ENOTDIR check) |
| `packages/core/src/types.ts` | 277 | New `ClearSessionsResult.skippedProjectCount?: number` |
| `packages/core/src/session/cleanup.ts` | 37 (`getMostRecentSessionMtime`) | `await fs.readdir().catch(narrow → [])` |
| `packages/core/src/session/cleanup.ts` | 297 (Step 1, `clearInvalid`) | `Effect.tryPromise({ try, catch })` + `Effect.catchAll(narrow → succeed([]) / fail)` |
| `packages/core/src/session/cleanup.ts` | 338 (Step 2, `clearEmpty` / `listSessions` caller) | `listSessions(...).pipe(Effect.catchAll(narrow))` |
| `packages/core/src/session/cleanup.ts` | 378 (Step 4, `clearOrphanAgents` / `deleteOrphanAgents` caller) | `deleteOrphanAgents(...).pipe(Effect.catchAll(narrow))` |
| `packages/core/src/session/cleanup.ts` | 369 (Step 6, `deduplicateTitles`) | same narrow `tryPromise + catchAll` pattern |
| `packages/core/src/session/cleanup.ts` | (Set + return) | `skippedProjects: Set<string>` tracked per-run, surfaced via `result.skippedProjectCount` |
| `packages/core/src/session/projects.ts` | 31 (`listProjects` per-entry) | `tryPromise({try, catch})` + `Effect.catchAll(narrow → succeed(null))`, filter with type guard |

## Test Plan

- [x] `pnpm --filter @claude-sessions/core test` — **446 / 446 pass** (9 new + 437 existing)
  - T1: clearSessions Step 1 skips a project whose folder vanishes before readdir
  - T2: clearSessions Step 6 skips a project that vanishes between Step 1 and Step 6
  - T4: listProjects skips an entry whose folder vanishes between top-level and per-entry readdir
  - T5: listProjects returns other valid projects when one entry's readdir fails
  - T6: clearSessions Step 1 PROPAGATES non-ENOENT (EACCES) errors (does not silently skip)
  - T7: listProjects PROPAGATES non-ENOENT (EACCES) errors
  - T8: clearSessions Step 2 (`listSessions`) skips a project whose folder vanishes
  - T9: clearSessions Step 4 (`deleteOrphanAgents`) skips a project whose folder vanishes
  - T10: clearSessions reports `skippedProjectCount` (unique per project across steps, not per step × project)
- [x] `pnpm typecheck` — 0 errors across all packages
- [x] `pnpm --filter @claude-sessions/core build` — success
- [x] `pnpm --filter @claude-sessions/core lint` — 0 errors (16 pre-existing warnings unrelated)

## What's NOT in this PR (Follow-up)

- T3 (`getMostRecentSessionMtime` ENOENT via mock) was explored but proved brittle because `previewCleanup`'s chain calls `readdir` on the same `projectPath` through several still-unguarded sites (`crud-streaming`, `crud.readSessionMeta`, `agents.findOrphanAgents`, `todos`). The one-line `getMostRecentSessionMtime` guard here is verified via code review; broader `readdir` hardening across the previewCleanup chain (and a unit test for the mtime probe in isolation) is a logical follow-up.
- PR #146's restoration plan items (OS-aware path detection, reversible deletion, per-project explicit UI confirmation) are also distinct follow-ups — they extend the cleanup feature surface rather than fix this TOCTOU gap.
- Vitest partial-mock `default:` interop pattern (used in `cleanup.test.ts` / `projects.test.ts` for selective `fs.readdir` ENOENT injection) is project-typical but brittle. Long-term refactor candidate: a `FileSystem` DI seam threaded through `cleanup` / `projects` / `crud-streaming`, removing the need for module-level `vi.mock` of `node:fs/promises`. Out of scope for this PR.

## References

- Relates to #103
- Builds on PR #143 (`detectStaleProject`, grace period) and PR #146 (vscode-ext inert call removal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when project/session directories vanish mid-run: cleanup and listing now skip missing directories, continue processing, and still surface non-missing-folder errors.
  * Cleanup results now include a skippedProjectCount to indicate how many unique projects were skipped.

* **Tests**
  * Added comprehensive tests covering vanished directories, selective ENOENT handling, and non-ENOENT error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
