### PR TITLE
test: add coverage for session search and webview session page

### DIFF
--- a/packages/core/src/session/search.test.ts
+++ b/packages/core/src/session/search.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { Effect } from 'effect'
+
+vi.mock('../paths.js', async () => {
+  const actual = await vi.importActual<typeof import('../paths.js')>('../paths.js')
+  return {
+    ...actual,
+    getSessionsDir: vi.fn(),
+  }
+})
+
+import { extractSnippet, findContentMatch, searchSessions } from './search.js'
+import { getSessionsDir } from '../paths.js'
+
+// ---------------------------------------------------------------------------
+// Pure function tests (no mocking, no filesystem)
+// ---------------------------------------------------------------------------
+
+describe('extractSnippet', () => {
+  it('returns the full text trimmed when match sits at index 0 and text is short', () => {
+    const text = 'hello world'
+    expect(extractSnippet(text, 0, 5)).toBe('hello world')
+  })
+
+  it('omits the leading ellipsis when start is 0 (matchIndex within 50 chars)', () => {
+    const text = 'hello world plus some trailing context that is longer than fifty chars'
+    const result = extractSnippet(text, 0, 5)
+    expect(result.startsWith('...')).toBe(false)
+    expect(result.startsWith('hello')).toBe(true)
+  })
+
+  it('adds leading and trailing ellipsis when match is in the middle of long text', () => {
+    const prefix = 'a'.repeat(80)
+    const suffix = 'b'.repeat(80)
+    const text = `${prefix}NEEDLE${suffix}`
+    const matchIndex = prefix.length
+    const result = extractSnippet(text, matchIndex, 6)
+    expect(result.startsWith('...')).toBe(true)
+    expect(result.endsWith('...')).toBe(true)
+    expect(result).toContain('NEEDLE')
+  })
+
+  it('omits the trailing ellipsis when end reaches text.length', () => {
+    const prefix = 'a'.repeat(80)
+    const text = `${prefix}NEEDLE`
+    const matchIndex = prefix.length
+    const result = extractSnippet(text, matchIndex, 6)
+    expect(result.startsWith('...')).toBe(true)
+    expect(result.endsWith('...')).toBe(false)
+    expect(result.endsWith('NEEDLE')).toBe(true)
+  })
+})
+
+describe('findContentMatch', () => {
+  const filePath = '/tmp/test-session.jsonl'
+
+  function makeUserMessage(uuid: string, text: string, timestamp = '2026-01-01T00:00:00.000Z') {
+    return JSON.stringify({
+      type: 'user',
+      uuid,
+      timestamp,
+      message: { role: 'user', content: [{ type: 'text', text }] },
+    })
+  }
+
+  function makeAssistantMessage(
+    uuid: string,
+    text: string,
+    timestamp = '2026-01-01T00:00:00.000Z'
+  ) {
+    return JSON.stringify({
+      type: 'assistant',
+      uuid,
+      timestamp,
+      message: { role: 'assistant', content: [{ type: 'text', text }] },
+    })
+  }
+
+  function makeSummary(leafUuid: string) {
+    return JSON.stringify({ type: 'summary', summary: 'irrelevant', leafUuid })
+  }
+
+  it('returns the matching user message with a snippet', () => {
+    const lines = [
+      makeUserMessage('u-1', 'first message without the keyword'),
+      makeUserMessage('u-2', 'second message contains NEEDLE inside it'),
+    ]
+    const result = findContentMatch(lines, 'needle', filePath)
+    expect(result).not.toBeNull()
+    expect(result?.msg.uuid).toBe('u-2')
+    expect(result?.snippet).toContain('NEEDLE')
+  })
+
+  it('matches assistant messages too', () => {
+    const lines = [makeAssistantMessage('a-1', 'assistant says NEEDLE here')]
+    const result = findContentMatch(lines, 'needle', filePath)
+    expect(result?.msg.uuid).toBe('a-1')
+  })
+
+  it('skips non-user/non-assistant message types', () => {
+    const lines = [makeSummary('leaf-1'), makeUserMessage('u-1', 'plain user content with NEEDLE')]
+    const result = findContentMatch(lines, 'needle', filePath)
+    expect(result?.msg.uuid).toBe('u-1')
+  })
+
+  it('is case-insensitive on the query side (caller passes lowercased query)', () => {
+    const lines = [makeUserMessage('u-1', 'mixed Case NeEdLe here')]
+    const result = findContentMatch(lines, 'needle', filePath)
+    expect(result?.msg.uuid).toBe('u-1')
+  })
+
+  it('returns null when no message contains the query', () => {
+    const lines = [
+      makeUserMessage('u-1', 'no match here'),
+      makeUserMessage('u-2', 'still no match'),
+    ]
+    expect(findContentMatch(lines, 'needle', filePath)).toBeNull()
+  })
+
+  it('skips invalid JSON lines and continues searching', () => {
+    const lines = ['{ not valid json', makeUserMessage('u-1', 'real message with NEEDLE')]
+    const result = findContentMatch(lines, 'needle', filePath)
+    expect(result?.msg.uuid).toBe('u-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Effect-based integration tests (uses a real temp directory + mocked paths.js)
+// ---------------------------------------------------------------------------
+
+describe('searchSessions', () => {
+  let tempDir: string
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'search-test-'))
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  async function writeSessionFile(
+    projectName: string,
+    sessionId: string,
+    userText: string,
+    timestamp = '2026-01-01T00:00:00.000Z'
+  ) {
+    const projectDir = path.join(tempDir, projectName)
+    await fs.mkdir(projectDir, { recursive: true })
+    const content =
+      JSON.stringify({
+        type: 'user',
+        uuid: `msg-${sessionId}`,
+        timestamp,
+        message: { role: 'user', content: [{ type: 'text', text: userText }] },
+      }) + '\n'
+    await fs.writeFile(path.join(projectDir, `${sessionId}.jsonl`), content, 'utf-8')
+  }
+
+  // Write a session whose first user message (title source) differs from a later
+  // user message that contains the search query. Used to verify the title vs
+  // content phase distinction.
+  async function writeSessionWithDistinctTitleAndContent(
+    projectName: string,
+    sessionId: string,
+    firstUserText: string,
+    laterUserText: string,
+    timestamp = '2026-01-01T00:00:00.000Z'
+  ) {
+    const projectDir = path.join(tempDir, projectName)
+    await fs.mkdir(projectDir, { recursive: true })
+    const lines = [
+      JSON.stringify({
+        type: 'user',
+        uuid: `msg-${sessionId}-1`,
+        timestamp,
+        message: { role: 'user', content: [{ type: 'text', text: firstUserText }] },
+      }),
+      JSON.stringify({
+        type: 'user',
+        uuid: `msg-${sessionId}-2`,
+        timestamp,
+        message: { role: 'user', content: [{ type: 'text', text: laterUserText }] },
+      }),
+    ]
+    await fs.writeFile(
+      path.join(projectDir, `${sessionId}.jsonl`),
+      lines.join('\n') + '\n',
+      'utf-8'
+    )
+  }
+
+  it('finds sessions whose title matches the query (title-only phase)', async () => {
+    await writeSessionFile('-Users-test-project-a', 'sess-1', 'NEEDLE in title')
+    await writeSessionFile('-Users-test-project-a', 'sess-2', 'unrelated content')
+
+    const results = await Effect.runPromise(searchSessions('needle'))
+
+    expect(results.map((r) => r.sessionId)).toContain('sess-1')
+    expect(results.map((r) => r.sessionId)).not.toContain('sess-2')
+    expect(results[0].matchType).toBe('title')
+  })
+
+  it('finds sessions by content when searchContent is true', async () => {
+    await writeSessionFile('-Users-test-project-a', 'sess-1', 'plain title')
+    await writeSessionWithDistinctTitleAndContent(
+      '-Users-test-project-a',
+      'sess-2',
+      'innocuous opening line',
+      'this later message has NEEDLE inside'
+    )
+
+    const titleOnly = await Effect.runPromise(searchSessions('needle'))
+    expect(titleOnly).toHaveLength(0)
+
+    const withContent = await Effect.runPromise(searchSessions('needle', { searchContent: true }))
+    const ids = withContent.map((r) => r.sessionId)
+    expect(ids).toContain('sess-2')
+    expect(withContent.find((r) => r.sessionId === 'sess-2')?.matchType).toBe('content')
+  })
+
+  it('narrows results when projectName filter is provided', async () => {
+    await writeSessionFile('-Users-test-project-a', 'sess-a', 'NEEDLE here')
+    await writeSessionFile('-Users-test-project-b', 'sess-b', 'NEEDLE there')
+
+    const all = await Effect.runPromise(searchSessions('needle'))
+    expect(all.map((r) => r.sessionId).sort()).toEqual(['sess-a', 'sess-b'])
+
+    const filtered = await Effect.runPromise(
+      searchSessions('needle', { projectName: '-Users-test-project-a' })
+    )
+    expect(filtered.map((r) => r.sessionId)).toEqual(['sess-a'])
+  })
+
+  it('sorts results by timestamp newest first', async () => {
+    await writeSessionFile(
+      '-Users-test-project-a',
+      'sess-old',
+      'NEEDLE old',
+      '2026-01-01T00:00:00.000Z'
+    )
+    await writeSessionFile(
+      '-Users-test-project-a',
+      'sess-new',
+      'NEEDLE new',
+      '2026-06-01T00:00:00.000Z'
+    )
+
+    const results = await Effect.runPromise(searchSessions('needle'))
+    expect(results.map((r) => r.sessionId)).toEqual(['sess-new', 'sess-old'])
+  })
+
+  it('returns an empty array when no projects exist', async () => {
+    // tempDir is empty (no project directories)
+    const results = await Effect.runPromise(searchSessions('needle'))
+    expect(results).toEqual([])
+  })
+})

--- a/packages/core/src/session/search.ts
+++ b/packages/core/src/session/search.ts
@@ -11,14 +11,14 @@ import { listSessions } from './crud.js'
 import type { Message, SearchResult, Project } from '../types.js'
 
 // Pure function: extract snippet around match
-const extractSnippet = (text: string, matchIndex: number, queryLength: number): string => {
+export const extractSnippet = (text: string, matchIndex: number, queryLength: number): string => {
   const start = Math.max(0, matchIndex - 50)
   const end = Math.min(text.length, matchIndex + queryLength + 50)
   return (start > 0 ? '...' : '') + text.slice(start, end).trim() + (end < text.length ? '...' : '')
 }
 
 // Pure function: find first matching message in session content
-const findContentMatch = (
+export const findContentMatch = (
   lines: string[],
   queryLower: string,
   filePath: string

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -376,6 +376,93 @@ suite('Webview Test Suite', () => {
     )
   })
 
+  test('Session page responds with HTTP 200', async function () {
+    if (process.env.CI) {
+      console.log('Skipping session page test in CI environment')
+      this.skip()
+      return
+    }
+
+    this.timeout(60000)
+
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
+    if (!extension) {
+      assert.fail('Extension not found: es6kr.claude-sessions')
+    }
+
+    if (!extension.isActive) {
+      await extension.activate()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // Use local build instead of npx to test current source
+    const webBuildPath = path.resolve(__dirname, '../../../../web/dist/cli.js')
+    if (fs.existsSync(webBuildPath)) {
+      const config = vscode.workspace.getConfiguration('claudeSessions')
+      await config.update('webServerPath', webBuildPath, vscode.ConfigurationTarget.Global)
+      console.log(`Using local web build: ${webBuildPath}`)
+    }
+
+    // Resolve a real session from disk so the server can render the page
+    const sessionInfo = findFirstSession()
+    if (!sessionInfo) {
+      console.log('No sessions found in ~/.claude/projects, skipping')
+      this.skip()
+      return
+    }
+
+    await vscode.commands.executeCommand('claudeSessions.restartWebServer')
+    console.log('restartWebServer executed, polling for server readiness...')
+
+    const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
+
+    // Wait for /api/version first (server is ready)
+    const maxRetries = 10
+    const retryInterval = 1000
+    for (let i = 0; i < maxRetries; i++) {
+      try {
+        const result = await new Promise<{ statusCode: number }>((resolve, reject) => {
+          const req = http.get(`http://localhost:${port}/api/version`, (res) => {
+            res.resume()
+            res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
+          })
+          req.on('error', reject)
+          req.setTimeout(3000, () => {
+            req.destroy()
+            reject(new Error('timeout'))
+          })
+        })
+        if (result.statusCode === 200) break
+      } catch {
+        console.log(`Retry ${i + 1}/${maxRetries}: server not ready yet`)
+        await new Promise((resolve) => setTimeout(resolve, retryInterval))
+      }
+    }
+
+    // Now fetch the session page that the VSCode webview actually loads
+    const sessionPath = `/session/${encodeURIComponent(sessionInfo.projectName)}/${encodeURIComponent(sessionInfo.sessionId)}`
+    const sessionResult = await new Promise<{ statusCode: number }>((resolve, reject) => {
+      const req = http.get(`http://localhost:${port}${sessionPath}`, (res) => {
+        res.resume()
+        res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
+      })
+      req.on('error', reject)
+      req.setTimeout(5000, () => {
+        req.destroy()
+        reject(new Error('Session page request timeout'))
+      })
+    })
+
+    console.log(`Web server ${sessionPath} responded with status: ${sessionResult.statusCode}`)
+    assert.strictEqual(
+      sessionResult.statusCode,
+      200,
+      `Session page should respond with HTTP 200, got ${sessionResult.statusCode}`
+    )
+  })
+
   test('Custom Editor activates for .jsonl files', async function () {
     this.timeout(30000)
 


### PR DESCRIPTION
## Summary

Bundle two test-only additions in one PR (per user direction):

- **`packages/core`** (closes #122): adds `packages/core/src/session/search.test.ts` covering previously-untested search functions.
  - Pure functions `extractSnippet`, `findContentMatch` — promoted from module-private to `export` so they can be unit-tested directly.
  - Effect-based `searchSessions` — exercised via temp directory + mocked `getSessionsDir`.
- **`packages/vscode-extension`** (closes #108): adds `Session page responds with HTTP 200` test to `webview.test.ts`. Covers the `/session/{projectName}/{sessionId}` URL that the VSCode webview actually loads via `openSession`, which existing `/api/version` and `/` tests did not exercise.

Both changes are additive. No production behavior is modified.

## Trade-offs

- **`extractSnippet` / `findContentMatch` are now exported.** Tiny API surface increase; existing consumers were already using `searchSessions` etc. No tree-shaking impact. (Verified: helpers are NOT re-exported from `packages/core/src/index.ts` nor `packages/core/src/session.ts` — the package entrypoint surface is unchanged; only the deep import `@claude-sessions/core/src/session/search.js` can reach them.)
- **Webview test uses `findFirstSession()` instead of the `CLAUDE_SESSIONS_DIR` env approach the issue body sketched.** `runTest.ts` does not actually set that variable today, and adding it would change every other webview test's data source. `findFirstSession()` matches the existing 4 HTTP tests' convention and keeps blast radius zero. The deviation is intentional and documented in the commit message. CodeRabbit raised this same concern (#163#discussion_r3295016769) and is partially correct — the hermetic-fixture redesign deserves a coordinated follow-up that migrates all 4 HTTP tests together, tracked in a separate issue rather than expanded in this PR.
- **Single PR for two issues** — atomic merge, less review overhead. If one half fails review it can be peeled off into a separate PR before merge.

## Test plan

- [x] CI: `pnpm test` (core) — 15 new search tests pass alongside existing 11 projects tests (CI run [26366523794](https://github.com/es6kr/claude-code-sessions/actions/runs/26366523794) — ubuntu + windows green)
- [x] CI: `pnpm build` (root) — full monorepo build succeeds (same CI run)
- [x] CI: `pnpm typecheck` (vscode-extension) — no errors (same CI run)
- [ ] Local (skipped in CI per `process.env.CI` guard): `pnpm test` (vscode-extension) — new `Session page responds with HTTP 200` test exits 200 against the locally-built web server using a real session from `~/.claude/projects/`
- [x] CodeRabbit walkthrough — review for missed edge cases (walkthrough + 1 inline finding posted; Internal Code Review responds at #163#issuecomment-4529456871)

## Notes

- Branch from `origin/main` (3b37697)
- 2 commits: `test(core): ... (#122)` and `test(vsx): ... (#108)`
- Closes both linked issues on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal helper functions refactored for improved modularity.

* **Tests**
  * Added comprehensive test coverage for session search functionality including snippet extraction and content matching.
  * Added integration tests for session filtering and search capabilities.
  * Added HTTP response validation tests for session pages in VSCode extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
