### PR TITLE
fix(web): normalize Content shapes before message categorization

### DIFF
--- a/packages/web/src/lib/utils/message.test.ts
+++ b/packages/web/src/lib/utils/message.test.ts
@@ -114,6 +114,46 @@ describe('getMessageCategory', () => {
     const msg = makeMsg({ type: 'assistant', message: { content: 'plain string' } })
     expect(getMessageCategory(msg)).toBe('assistant')
   })
+
+  // Regression: Content can be string | ContentItem | ContentItem[]; previously the
+  // categorizer only inspected the array form. See #123.
+
+  it('should categorize user message with single tool_result ContentItem as tool_result', () => {
+    const msg = makeMsg({
+      type: 'user',
+      message: { content: { type: 'tool_result', tool_use_id: 'id', content: 'r' } },
+    })
+    expect(getMessageCategory(msg)).toBe('tool_result')
+  })
+
+  it('should categorize assistant with single tool_use ContentItem as tool_use', () => {
+    const msg = makeMsg({
+      type: 'assistant',
+      message: { content: { type: 'tool_use', id: 'tu1', name: 'Read', input: {} } },
+    })
+    expect(getMessageCategory(msg)).toBe('tool_use')
+  })
+
+  it('should categorize assistant with single thinking ContentItem as thinking', () => {
+    const msg = makeMsg({
+      type: 'assistant',
+      message: { content: { type: 'thinking', thinking: 'hmm' } },
+    })
+    expect(getMessageCategory(msg)).toBe('thinking')
+  })
+
+  it('should categorize assistant with single text ContentItem as assistant', () => {
+    const msg = makeMsg({
+      type: 'assistant',
+      message: { content: { type: 'text', text: 'Hi' } },
+    })
+    expect(getMessageCategory(msg)).toBe('assistant')
+  })
+
+  it('should categorize user with string content as user (no tool_result inferred)', () => {
+    const msg = makeMsg({ type: 'user', message: { content: 'plain string' } })
+    expect(getMessageCategory(msg)).toBe('user')
+  })
 })
 
 describe('ALL_MESSAGE_CATEGORIES', () => {

--- a/packages/web/src/lib/utils/message.ts
+++ b/packages/web/src/lib/utils/message.ts
@@ -2,8 +2,27 @@
  * Message content utilities
  */
 
-import type { Content, Message } from '$lib/api'
+import type { Content, ContentItem, Message } from '$lib/api'
 import { maskHomePath } from '$lib/stores/config'
+
+/**
+ * Normalize Content into a uniform ContentItem array for inspection.
+ *
+ * Content can be a string, a single ContentItem, or an array of ContentItems
+ * (see api.ts). Categorization logic must look at the items inside, so each
+ * shape is normalized to the array form here.
+ *
+ * - `string` -> `[{ type: 'text', text }]`
+ * - single `ContentItem` -> `[item]`
+ * - `ContentItem[]` -> pass through
+ */
+export const normalizeContent = (content: Content): ContentItem[] => {
+  if (typeof content === 'string') {
+    return [{ type: 'text', text: content } as ContentItem]
+  }
+  if (Array.isArray(content)) return content
+  return [content]
+}
 
 export type MessageCategory =
   | 'assistant'
@@ -24,6 +43,11 @@ const METADATA_TYPES = new Set([
   'queue-operation',
 ])
 
+type CategoryContentItem = ContentItem & {
+  text?: string
+  thinking?: string
+}
+
 export const getMessageCategory = (msg: Message): MessageCategory => {
   if (METADATA_TYPES.has(msg.type)) return 'metadata'
   if (msg.type === 'progress') return 'progress'
@@ -32,20 +56,21 @@ export const getMessageCategory = (msg: Message): MessageCategory => {
   if (msg.type === 'human') return 'user'
 
   if (msg.type === 'user') {
-    const m = msg.message as { content?: unknown[] } | undefined
-    if (Array.isArray(m?.content)) {
-      const first = m.content[0] as { type?: string } | undefined
-      if (first?.type === 'tool_result') return 'tool_result'
+    const m = msg.message as { content?: Content } | undefined
+    if (m?.content) {
+      const items = normalizeContent(m.content)
+      if (items[0]?.type === 'tool_result') return 'tool_result'
     }
     return 'user'
   }
 
   if (msg.type === 'assistant') {
-    const m = msg.message as { content?: Array<Record<string, unknown>> } | undefined
-    if (Array.isArray(m?.content)) {
-      if (m.content.some((c) => c?.type === 'tool_use')) return 'tool_use'
-      const hasText = m.content.some((c) => c?.type === 'text' && (c?.text as string)?.trim())
-      if (!hasText && m.content.some((c) => c?.type === 'thinking')) return 'thinking'
+    const m = msg.message as { content?: Content } | undefined
+    if (m?.content) {
+      const items = normalizeContent(m.content) as CategoryContentItem[]
+      if (items.some((c) => c?.type === 'tool_use')) return 'tool_use'
+      const hasText = items.some((c) => c?.type === 'text' && c?.text?.trim())
+      if (!hasText && items.some((c) => c?.type === 'thinking')) return 'thinking'
     }
     return 'assistant'
   }


### PR DESCRIPTION
## Summary

Fix `getMessageCategory` for the non-array shapes of `Content`. Previously, when `m.message.content` was a single `ContentItem` (e.g. `{ type: 'tool_result', ... }`) instead of `ContentItem[]`, the `Array.isArray()` gate skipped the tool_result / tool_use / thinking detection and the message fell back to the default `'user'` / `'assistant'` category.

- Add `normalizeContent(content: Content): ContentItem[]` helper:
  - `string` → `[{ type: 'text', text: content }]`
  - single `ContentItem` → `[item]`
  - `ContentItem[]` → pass through
- Use the helper in both `user` and `assistant` branches of `getMessageCategory`.
- Add 5 regression tests covering all Content shapes per category outcome.

No application behavior change for messages that already used the array form. Single-item and string forms are now categorized correctly.

Relates to #123

## Test plan

- [x] `pnpm --filter @claude-sessions/web vitest run src/lib/utils/message.test.ts` — 60/60 pass (3 newly added covering single ContentItem cases + 2 sanity + 55 existing, no regression)
- [x] `pnpm --filter @claude-sessions/web typecheck` — clean (exit 0)
- [x] Pre-push hook executed full project build + typecheck + tests on push

## Files changed

| File | Change |
|------|--------|
| `packages/web/src/lib/utils/message.ts` | Added `normalizeContent` helper, refactored `getMessageCategory` user/assistant branches to use it |
| `packages/web/src/lib/utils/message.test.ts` | Added 5 tests for non-array Content shapes |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message content handling to normalize and properly categorize messages with various content formats.

* **Tests**
  * Extended test coverage for message categorization to include edge cases for different content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->