### PR TITLE
feat(vscode): integrate Claude Code extension as 3rd resume option (discussion #159 M2)

### DIFF
--- a/.claude/rules/vscode-uri-scheme.md
+++ b/.claude/rules/vscode-uri-scheme.md
@@ -1,0 +1,44 @@
+# VSCode URI Scheme
+
+## `vscode://` hardcode forbidden — use `vscode.env.uriScheme` (HARD STOP)
+
+**Extension code must NOT hardcode `vscode://`, `vscode-insiders://`, or any literal IDE scheme.** Always derive the scheme dynamically via `vscode.env.uriScheme`.
+
+### Why
+
+- The VSCode core API contract requires every fork to implement `vscode.env.uriScheme` and return its own scheme:
+  - VSCode → `vscode`
+  - Cursor → `cursor`
+  - Antigravity → `antigravity`
+  - VSCodium → `vscodium`
+- When `vscode://...` is hardcoded, `vscode.env.openExternal` hands the URI to the OS launcher (macOS Launch Services / Windows shell). The OS resolves the scheme to the **real VSCode app** even when the user is running a fork.
+- Result: a user on Cursor or Antigravity who clicks "Resume in Claude Code Extension" sees VSCode boot up — the session resolution fails (the JSONL lives in the fork's project tree, not VSCode's) and an empty session opens.
+- Anthropic's official `claude-code` extension is published to Open VSX (publisher `Anthropic`, v2.1.168+) and installs on every Open VSX-supported fork, so the in-process dispatch via `vscode.env.uriScheme` reaches the registered UriHandler natively.
+
+### Don't / Do
+
+| #   | Don't                                                                                                     | Do                                                                                                                                                                                                                  |
+| --- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | ``vscode.Uri.parse(`vscode://publisher.extension/path`)``                                                 | ``vscode.Uri.parse(`${vscode.env.uriScheme}://publisher.extension/path`)``                                                                                                                                          |
+| 2   | Comment that documents the URI shape with a literal scheme (`// vscode://anthropic.claude-code/open?...`) | Use a placeholder in comments: `// <ide-scheme>://anthropic.claude-code/open?...`                                                                                                                                   |
+| 3   | Assume "vscode:// will be recognized by forks too"                                                        | Each fork only handles its own scheme in-process. Cross-scheme URIs fall back to the OS launcher → VSCode                                                                                                           |
+| 4   | `vscode.commands.executeCommand('vscode.open', uri)` to invoke another extension's UriHandler             | Use `vscode.env.openExternal(uri)`. `vscode.open` resolves the URI as a file path (EntryNotFound) and does NOT trigger the registered UriHandler — verified end-to-end on the PoC branch `feat/resume-in-extension` |
+
+### Self-check (before every edit that introduces a URI literal)
+
+1. Does the new code contain a `vscode://` literal substring? — `grep 'vscode://'` mentally
+2. If yes, replace with `${vscode.env.uriScheme}://`
+3. Does a comment quote a URI shape with `vscode://`? — Replace with the `<ide-scheme>://` placeholder
+4. For URI handler dispatch, use `vscode.env.openExternal(uri)` — never `vscode.commands.executeCommand('vscode.open', uri)` for cross-extension dispatch
+
+### Scope
+
+- Runtime extension code that constructs or quotes IDE URIs
+- Comment-level URI shape documentation (use placeholders, not literals)
+
+### Allowed exceptions
+
+- README / user-facing docs that show "click `vscode://...` in VSCode" as a concrete user example
+- Quoting upstream VSCode-only API docs (`vscode://docs/...`) when explicitly referencing a VSCode-specific behavior
+
+Anything else in runtime extension code must derive the scheme from `vscode.env.uriScheme`.

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-sessions",
   "displayName": "Claude Code Sessions",
   "description": "Manage Claude Code sessions from VS Code sidebar",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "publisher": "es6kr",
   "license": "MIT",
   "repository": {

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -457,12 +457,13 @@
         "claudeSessions.defaultTerminalMode": {
           "type": "string",
           "enum": [
+            "anthropic",
             "ask",
             "external",
             "internal"
           ],
           "default": "ask",
-          "description": "Default terminal mode when resuming sessions: 'ask' shows a picker, 'internal' uses the integrated terminal, 'external' uses the system terminal"
+          "description": "Default mode when resuming sessions: 'ask' shows a picker, 'internal' uses the integrated terminal, 'external' uses the system terminal, 'anthropic' opens the session inside the official Claude Code extension (anthropic.claude-code)"
         },
         "claudeSessions.webServerPath": {
           "type": "string",

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -6,6 +6,7 @@ import { Effect } from 'effect'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { outputChannel } from './output'
 import { SESSION_EDITOR_VIEW_TYPE, SessionEditorProvider } from './sessionEditorProvider'
+import { decideResume, type ResumeMode } from './lib/crossWorkspace'
 
 let webServerProcess: ChildProcess | null = null
 
@@ -695,38 +696,64 @@ export function activate(context: vscode.ExtensionContext) {
         // Get project path for cwd (needed for all modes)
         const cwd = await resolveProjectCwd(item.projectName)
 
-        // Determine resume mode: skip picker if pre-configured
-        let mode: 'internal' | 'external' | 'anthropic'
-        if (
-          defaultTerminalMode === 'internal' ||
-          defaultTerminalMode === 'external' ||
-          defaultTerminalMode === 'anthropic'
-        ) {
-          mode = defaultTerminalMode
+        // Single source of truth for picker options — reused by the primary
+        // 3-way picker AND the cross-workspace fallback 2-way picker so the
+        // labels/descriptions stay in sync without duplication.
+        const INTERNAL_OPTION = {
+          label: '$(terminal) Internal Terminal',
+          description: 'Open in VSCode integrated terminal',
+          mode: 'internal' as const,
+        }
+        const EXTERNAL_OPTION = {
+          label: '$(link-external) External Terminal',
+          description: 'Open in system default terminal',
+          mode: 'external' as const,
+        }
+        const ANTHROPIC_OPTION = {
+          label: '$(window) Claude Code Extension',
+          description: 'Open inside the official Claude Code extension',
+          mode: 'anthropic' as const,
+        }
+
+        // The resume-mode decision is delegated to the pure-function
+        // `decideResume` (src/lib/crossWorkspace.ts), unit-tested via
+        // src/test/suite/crossWorkspace.test.ts. It returns one of:
+        //   - { kind: 'direct',          mode }                   → dispatch immediately
+        //   - { kind: 'picker',          options: [...] }         → show primary picker
+        //   - { kind: 'fallback-picker', options: [...], reason } → show fallback picker
+        //
+        // The picker branches share the option metadata (label, description,
+        // icon) defined above; the pure function only emits mode names.
+        const folders = vscode.workspace.workspaceFolders ?? []
+        const decision = decideResume({
+          defaultMode: defaultTerminalMode as 'ask' | ResumeMode,
+          cwd,
+          folders,
+        })
+        outputChannel.appendLine(
+          `[resumeSession] cwd=${cwd ?? '<empty>'} folders=[${folders
+            .map((f) => f.uri.fsPath)
+            .join(', ')}] decision=${decision.kind}`
+        )
+
+        const MODE_TO_OPTION = {
+          internal: INTERNAL_OPTION,
+          external: EXTERNAL_OPTION,
+          anthropic: ANTHROPIC_OPTION,
+        } as const
+
+        let mode: ResumeMode
+        if (decision.kind === 'direct') {
+          mode = decision.mode
         } else {
-          const choice = await vscode.window.showQuickPick(
-            [
-              {
-                label: '$(terminal) Internal Terminal',
-                description: 'Open in VSCode integrated terminal',
-                mode: 'internal' as const,
-              },
-              {
-                label: '$(link-external) External Terminal',
-                description: 'Open in system default terminal',
-                mode: 'external' as const,
-              },
-              {
-                label: '$(window) Claude Code Extension',
-                description: 'Open inside the official anthropic.claude-code webview tab',
-                mode: 'anthropic' as const,
-              },
-            ],
-            {
-              placeHolder: 'Where to open Claude session?',
-              title: 'Resume Session',
-            }
-          )
+          const items = decision.options.map((m) => MODE_TO_OPTION[m])
+          const isFallback = decision.kind === 'fallback-picker'
+          const choice = await vscode.window.showQuickPick(items, {
+            placeHolder: isFallback
+              ? `Cross-workspace session (${cwd}) — Claude Code Extension cannot resolve. Fall back to:`
+              : 'Where to open Claude session?',
+            title: isFallback ? 'Resume Session (fallback)' : 'Resume Session',
+          })
 
           if (!choice) return
           mode = choice.mode
@@ -801,35 +828,17 @@ export function activate(context: vscode.ExtensionContext) {
             }
           }
 
-          // Cross-workspace hard block: anthropic.claude-code resolves sessions
-          // against the active workspace cwd, so a cross-workspace dispatch ends
-          // up loading an empty session instead of the requested one. Open
-          // Anyway is not a useful escape hatch — the user gets a broken
-          // session rather than a warning. Block + report; the user must open
-          // the session's folder as a workspace before resuming via Claude
-          // Code Extension.
-          // Iterate ALL workspaceFolders + normalize paths (lowercase + forward
-          // slashes) so multi-root + Windows case-mismatched drive letters
-          // count as same-workspace. (Pattern mirrors openOrRevealFolder.)
-          const normalizePath = (p: string) => p.toLowerCase().replace(/\\/g, '/')
-          const folders = vscode.workspace.workspaceFolders ?? []
-          const sessionCwdNorm = cwd ? normalizePath(cwd) : ''
-          const matchesAnyFolder = folders.some(
-            (f) => normalizePath(f.uri.fsPath) === sessionCwdNorm
-          )
-          if (folders.length > 0 && cwd && !matchesAnyFolder) {
-            const firstFolder = folders[0]?.uri.fsPath ?? ''
-            void vscode.window.showErrorMessage(
-              `Session belongs to "${cwd}" and cannot be resumed in the Claude Code Extension from the current workspace ("${firstFolder}"${folders.length > 1 ? ` and ${folders.length - 1} more` : ''}). Open the session's folder as a workspace first, or resume in Internal/External Terminal instead.`
-            )
-            return
-          }
-
-          // Dispatch via vscode.env.openExternal — this is the ONLY API that
-          // routes `vscode://<extension-id>/...` URIs through the registered
-          // UriHandler. vscode.commands.executeCommand('vscode.open', uri)
-          // resolves the URI as a file path (EntryNotFound) and does NOT
-          // trigger the extension's UriHandler. The PoC branch
+          // Cross-workspace dispatch is unreachable here: `decideResume`
+          // above converts cross-workspace + anthropic intent into a
+          // fallback-picker (Internal/External only). By the time control
+          // reaches this branch, the session cwd is guaranteed to match an
+          // open workspace folder, so the anthropic URI handler can resolve.
+          //
+          // Dispatch via vscode.env.openExternal — this is the
+          // ONLY API that routes `<ide-scheme>://<extension-id>/...` URIs
+          // through the registered UriHandler. vscode.commands.executeCommand(
+          // 'vscode.open', uri) resolves the URI as a file path (EntryNotFound)
+          // and does NOT trigger the extension's UriHandler. The PoC branch
           // feat/resume-in-extension verified this end-to-end.
           const uri = vscode.Uri.parse(
             `${vscode.env.uriScheme}://anthropic.claude-code/open?session=${encodeURIComponent(sessionId)}`

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -826,10 +826,8 @@ export function activate(context: vscode.ExtensionContext) {
           // routes `vscode://<extension-id>/...` URIs through the registered
           // UriHandler. vscode.commands.executeCommand('vscode.open', uri)
           // resolves the URI as a file path (EntryNotFound) and does NOT
-          // trigger the extension's UriHandler. PoC branch feat/resume-in-extension
-          // verified this end-to-end; Internal Review #3's `vscode.open`
-          // suggestion was incorrect and reverted after runtime verification
-          // (EntryNotFound observed in Antigravity console 2026-06-08).
+          // trigger the extension's UriHandler. The PoC branch
+          // feat/resume-in-extension verified this end-to-end.
           const uri = vscode.Uri.parse(
             `vscode://anthropic.claude-code/open?session=${encodeURIComponent(sessionId)}`
           )

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -695,9 +695,13 @@ export function activate(context: vscode.ExtensionContext) {
         // Get project path for cwd (needed for all modes)
         const cwd = await resolveProjectCwd(item.projectName)
 
-        // Determine terminal mode: skip picker if pre-configured
-        let mode: 'internal' | 'external'
-        if (defaultTerminalMode === 'internal' || defaultTerminalMode === 'external') {
+        // Determine resume mode: skip picker if pre-configured
+        let mode: 'internal' | 'external' | 'anthropic'
+        if (
+          defaultTerminalMode === 'internal' ||
+          defaultTerminalMode === 'external' ||
+          defaultTerminalMode === 'anthropic'
+        ) {
           mode = defaultTerminalMode
         } else {
           const choice = await vscode.window.showQuickPick(
@@ -711,6 +715,11 @@ export function activate(context: vscode.ExtensionContext) {
                 label: '$(link-external) External Terminal',
                 description: 'Open in system default terminal',
                 mode: 'external' as const,
+              },
+              {
+                label: '$(window) Claude Code Extension',
+                description: 'Open inside the official anthropic.claude-code webview tab',
+                mode: 'anthropic' as const,
               },
             ],
             {
@@ -731,7 +740,7 @@ export function activate(context: vscode.ExtensionContext) {
           })
           terminal.show()
           terminal.sendText(cliCommand)
-        } else {
+        } else if (mode === 'external') {
           // External: spawn detached process
           const extraArgs = cliFlags ? cliFlags.split(/\s+/).filter(Boolean) : []
           const result = resumeSession({
@@ -746,6 +755,53 @@ export function activate(context: vscode.ExtensionContext) {
             )
           } else {
             vscode.window.showErrorMessage(`Failed to resume session: ${result.error}`)
+          }
+        } else {
+          // anthropic: open inside the official Claude Code extension webview tab
+          // via its registered URI handler:
+          //   vscode://anthropic.claude-code/open?session=<sessionId>
+          // Addresses discussion #159 (option M2 — 3-way integrated picker).
+          const sessionId = String(item.sessionId ?? '')
+          if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
+            void vscode.window.showErrorMessage('Invalid session id; cannot resume session.')
+            return
+          }
+
+          const claudeExt = vscode.extensions.getExtension('anthropic.claude-code')
+          if (!claudeExt) {
+            const installChoice = await vscode.window.showWarningMessage(
+              'Claude Code extension (anthropic.claude-code) is not installed.',
+              'Install',
+              'Cancel'
+            )
+            if (installChoice === 'Install') {
+              await vscode.commands.executeCommand(
+                'workbench.extensions.installExtension',
+                'anthropic.claude-code'
+              )
+            }
+            return
+          }
+
+          // Cross-workspace warning (Issue 1, option C1 conservative default):
+          // anthropic.claude-code resolves sessions against the active workspace
+          // cwd, so sessions from other working directories will not open.
+          const currentWs = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+          if (currentWs && cwd && currentWs !== cwd) {
+            const proceed = await vscode.window.showWarningMessage(
+              `Session belongs to "${cwd}". The Claude Code extension only resumes sessions for the current workspace ("${currentWs}").`,
+              'Open Anyway',
+              'Cancel'
+            )
+            if (proceed !== 'Open Anyway') return
+          }
+
+          const uri = vscode.Uri.parse(
+            `vscode://anthropic.claude-code/open?session=${encodeURIComponent(sessionId)}`
+          )
+          const opened = await vscode.env.openExternal(uri)
+          if (!opened) {
+            void vscode.window.showErrorMessage('Failed to open session in Claude Code extension.')
           }
         }
       }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -798,14 +798,16 @@ export function activate(context: vscode.ExtensionContext) {
             }
           }
 
-          // Cross-workspace warning (Issue 1, option C1 conservative default):
-          // anthropic.claude-code resolves sessions against the active workspace
-          // cwd, so sessions from other working directories will not open.
+          // Cross-workspace hard block: anthropic.claude-code resolves sessions
+          // against the active workspace cwd, so a cross-workspace dispatch ends
+          // up loading an empty session instead of the requested one. Open
+          // Anyway is not a useful escape hatch — the user gets a broken
+          // session rather than a warning. Block + report; the user must open
+          // the session's folder as a workspace before resuming via Claude
+          // Code Extension.
           // Iterate ALL workspaceFolders + normalize paths (lowercase + forward
-          // slashes) — matches openOrRevealFolder's pattern; without this the
-          // check produces false-positive warnings on multi-root workspaces and
-          // on Windows case-mismatched drive letters. (PR #172 Internal Code
-          // Review #1 + CodeRabbit inline.)
+          // slashes) so multi-root + Windows case-mismatched drive letters
+          // count as same-workspace. (Pattern mirrors openOrRevealFolder.)
           const normalizePath = (p: string) => p.toLowerCase().replace(/\\/g, '/')
           const folders = vscode.workspace.workspaceFolders ?? []
           const sessionCwdNorm = cwd ? normalizePath(cwd) : ''
@@ -814,12 +816,10 @@ export function activate(context: vscode.ExtensionContext) {
           )
           if (folders.length > 0 && cwd && !matchesAnyFolder) {
             const firstFolder = folders[0]?.uri.fsPath ?? ''
-            const proceed = await vscode.window.showWarningMessage(
-              `Session belongs to "${cwd}". The Claude Code extension only resumes sessions for an open workspace folder (currently "${firstFolder}"${folders.length > 1 ? ` and ${folders.length - 1} more` : ''}).`,
-              'Open Anyway',
-              'Cancel'
+            void vscode.window.showErrorMessage(
+              `Session belongs to "${cwd}" and cannot be resumed in the Claude Code Extension from the current workspace ("${firstFolder}"${folders.length > 1 ? ` and ${folders.length - 1} more` : ''}). Open the session's folder as a workspace first, or resume in Internal/External Terminal instead.`
             )
-            if (proceed !== 'Open Anyway') return
+            return
           }
 
           // Dispatch via vscode.env.openExternal — this is the ONLY API that

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -783,25 +783,60 @@ export function activate(context: vscode.ExtensionContext) {
             return
           }
 
+          // Defensive activation: getExtension returns the Extension object even
+          // when it is installed-but-disabled (isActive === false). Without this
+          // step the URI dispatch below silently fails because no UriHandler is
+          // registered until activation. (PR #172 Internal Code Review #2.)
+          if (!claudeExt.isActive) {
+            try {
+              await claudeExt.activate()
+            } catch (err) {
+              void vscode.window.showErrorMessage(
+                `Failed to activate Claude Code extension: ${err instanceof Error ? err.message : String(err)}`
+              )
+              return
+            }
+          }
+
           // Cross-workspace warning (Issue 1, option C1 conservative default):
           // anthropic.claude-code resolves sessions against the active workspace
           // cwd, so sessions from other working directories will not open.
-          const currentWs = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
-          if (currentWs && cwd && currentWs !== cwd) {
+          // Iterate ALL workspaceFolders + normalize paths (lowercase + forward
+          // slashes) — matches openOrRevealFolder's pattern; without this the
+          // check produces false-positive warnings on multi-root workspaces and
+          // on Windows case-mismatched drive letters. (PR #172 Internal Code
+          // Review #1 + CodeRabbit inline.)
+          const normalizePath = (p: string) => p.toLowerCase().replace(/\\/g, '/')
+          const folders = vscode.workspace.workspaceFolders ?? []
+          const sessionCwdNorm = cwd ? normalizePath(cwd) : ''
+          const matchesAnyFolder = folders.some(
+            (f) => normalizePath(f.uri.fsPath) === sessionCwdNorm
+          )
+          if (folders.length > 0 && cwd && !matchesAnyFolder) {
+            const firstFolder = folders[0]?.uri.fsPath ?? ''
             const proceed = await vscode.window.showWarningMessage(
-              `Session belongs to "${cwd}". The Claude Code extension only resumes sessions for the current workspace ("${currentWs}").`,
+              `Session belongs to "${cwd}". The Claude Code extension only resumes sessions for an open workspace folder (currently "${firstFolder}"${folders.length > 1 ? ` and ${folders.length - 1} more` : ''}).`,
               'Open Anyway',
               'Cancel'
             )
             if (proceed !== 'Open Anyway') return
           }
 
+          // Dispatch in-process via vscode.open instead of vscode.env.openExternal:
+          // openExternal resolves true when the URI is handed off to the OS URI
+          // resolver — it does NOT confirm that anthropic.claude-code's
+          // UriHandler.handleUri ran successfully. vscode.open routes inside the
+          // IDE and surfaces failures synchronously, giving a usable error path.
+          // (PR #172 Internal Code Review #3.)
           const uri = vscode.Uri.parse(
             `vscode://anthropic.claude-code/open?session=${encodeURIComponent(sessionId)}`
           )
-          const opened = await vscode.env.openExternal(uri)
-          if (!opened) {
-            void vscode.window.showErrorMessage('Failed to open session in Claude Code extension.')
+          try {
+            await vscode.commands.executeCommand('vscode.open', uri)
+          } catch (err) {
+            void vscode.window.showErrorMessage(
+              `Failed to open session in Claude Code extension: ${err instanceof Error ? err.message : String(err)}`
+            )
           }
         }
       }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -822,21 +822,20 @@ export function activate(context: vscode.ExtensionContext) {
             if (proceed !== 'Open Anyway') return
           }
 
-          // Dispatch in-process via vscode.open instead of vscode.env.openExternal:
-          // openExternal resolves true when the URI is handed off to the OS URI
-          // resolver — it does NOT confirm that anthropic.claude-code's
-          // UriHandler.handleUri ran successfully. vscode.open routes inside the
-          // IDE and surfaces failures synchronously, giving a usable error path.
-          // (PR #172 Internal Code Review #3.)
+          // Dispatch via vscode.env.openExternal — this is the ONLY API that
+          // routes `vscode://<extension-id>/...` URIs through the registered
+          // UriHandler. vscode.commands.executeCommand('vscode.open', uri)
+          // resolves the URI as a file path (EntryNotFound) and does NOT
+          // trigger the extension's UriHandler. PoC branch feat/resume-in-extension
+          // verified this end-to-end; Internal Review #3's `vscode.open`
+          // suggestion was incorrect and reverted after runtime verification
+          // (EntryNotFound observed in Antigravity console 2026-06-08).
           const uri = vscode.Uri.parse(
             `vscode://anthropic.claude-code/open?session=${encodeURIComponent(sessionId)}`
           )
-          try {
-            await vscode.commands.executeCommand('vscode.open', uri)
-          } catch (err) {
-            void vscode.window.showErrorMessage(
-              `Failed to open session in Claude Code extension: ${err instanceof Error ? err.message : String(err)}`
-            )
+          const opened = await vscode.env.openExternal(uri)
+          if (!opened) {
+            void vscode.window.showErrorMessage('Failed to open session in Claude Code extension.')
           }
         }
       }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -759,7 +759,10 @@ export function activate(context: vscode.ExtensionContext) {
         } else {
           // anthropic: open inside the official Claude Code extension webview tab
           // via its registered URI handler:
-          //   vscode://anthropic.claude-code/open?session=<sessionId>
+          //   <ide-scheme>://anthropic.claude-code/open?session=<sessionId>
+          // where <ide-scheme> = vscode.env.uriScheme (vscode / cursor /
+          // antigravity / vscodium / ...) so the dispatch stays in-process
+          // on every Open VSX-supported fork.
           // Addresses discussion #159 (option M2 — 3-way integrated picker).
           const sessionId = String(item.sessionId ?? '')
           if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
@@ -829,7 +832,7 @@ export function activate(context: vscode.ExtensionContext) {
           // trigger the extension's UriHandler. The PoC branch
           // feat/resume-in-extension verified this end-to-end.
           const uri = vscode.Uri.parse(
-            `vscode://anthropic.claude-code/open?session=${encodeURIComponent(sessionId)}`
+            `${vscode.env.uriScheme}://anthropic.claude-code/open?session=${encodeURIComponent(sessionId)}`
           )
           const opened = await vscode.env.openExternal(uri)
           if (!opened) {

--- a/packages/vscode-extension/src/lib/crossWorkspace.ts
+++ b/packages/vscode-extension/src/lib/crossWorkspace.ts
@@ -34,23 +34,24 @@ export function normalizeWorkspacePath(p: string): string {
 }
 
 /**
- * `true` iff the session cwd matches the **active workspace folder
- * (folders[0])**. anthropic.claude-code resolves sessions against the active
+ * `true` iff the session cwd matches the **primary workspace folder
+ * (folders[0])**. anthropic.claude-code resolves sessions against the primary
  * workspace only — additional roots in a multi-root workspace do NOT enable
  * anthropic to resolve a session whose cwd lives outside folders[0]. Treats
  * null/empty cwd and empty folders as no-match. Windows case-mismatched drive
  * letters are normalized.
+ *
+ * Function name retains `…AnyWorkspaceFolder` for backward compatibility with
+ * existing call sites; semantics are folders[0]-only.
  */
 export function matchesAnyWorkspaceFolder(
   cwd: string | null | undefined,
   folders: ReadonlyArray<WorkspaceFolderLike>
 ): boolean {
   if (!cwd) return false
-  const cwdNorm = normalizeWorkspacePath(cwd)
-  if (!cwdNorm) return false
   const primary = folders[0]
   if (!primary) return false
-  return normalizeWorkspacePath(primary.uri.fsPath) === cwdNorm
+  return normalizeWorkspacePath(primary.uri.fsPath) === normalizeWorkspacePath(cwd)
 }
 
 /**

--- a/packages/vscode-extension/src/lib/crossWorkspace.ts
+++ b/packages/vscode-extension/src/lib/crossWorkspace.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure-function helpers for the resume-session decision flow.
+ *
+ * Extracted from extension.ts so the picker shape and the direct-open dispatch
+ * can be unit-tested without booting the VSCode test-electron host. The runtime
+ * caller passes the already-resolved `cwd` and `workspaceFolders` (mapped to
+ * `WorkspaceFolderLike` to keep this file free of vscode imports).
+ *
+ * Discussion #159 — 3-way picker (Internal / External / Claude Code Extension).
+ *
+ * anthropic.claude-code resolves sessions against the active workspace cwd only:
+ * if the session's project cwd is not exactly one of the open workspace folder
+ * paths, its URI handler loads an empty session. The picker hides ANTHROPIC
+ * up front in that case (better UX — no dead-end selection path); a fallback
+ * picker is shown if `defaultTerminalMode === 'anthropic'` would have skipped
+ * the picker entirely.
+ */
+
+export interface WorkspaceFolderLike {
+  uri: { fsPath: string }
+}
+
+export type ResumeMode = 'internal' | 'external' | 'anthropic'
+
+export type DefaultTerminalMode = 'ask' | ResumeMode
+
+export type ResumeDecision =
+  | { kind: 'direct'; mode: ResumeMode }
+  | { kind: 'picker'; options: ReadonlyArray<ResumeMode> }
+  | { kind: 'fallback-picker'; options: ReadonlyArray<ResumeMode>; reason: 'cross-workspace' }
+
+export function normalizeWorkspacePath(p: string): string {
+  return p.toLowerCase().replace(/\\/g, '/')
+}
+
+/**
+ * `true` iff the session cwd matches the **active workspace folder
+ * (folders[0])**. anthropic.claude-code resolves sessions against the active
+ * workspace only — additional roots in a multi-root workspace do NOT enable
+ * anthropic to resolve a session whose cwd lives outside folders[0]. Treats
+ * null/empty cwd and empty folders as no-match. Windows case-mismatched drive
+ * letters are normalized.
+ */
+export function matchesAnyWorkspaceFolder(
+  cwd: string | null | undefined,
+  folders: ReadonlyArray<WorkspaceFolderLike>
+): boolean {
+  if (!cwd) return false
+  const cwdNorm = normalizeWorkspacePath(cwd)
+  if (!cwdNorm) return false
+  const primary = folders[0]
+  if (!primary) return false
+  return normalizeWorkspacePath(primary.uri.fsPath) === cwdNorm
+}
+
+/**
+ * `true` iff the picker should hide ANTHROPIC_OPTION for this session. The
+ * exact rule is: hide unless the session cwd matches at least one open
+ * workspace folder. This collapses every "anthropic cannot resolve" case
+ * (no folders open, folders open but none match, no cwd) into one boolean.
+ */
+export function isCrossWorkspace(
+  cwd: string | null | undefined,
+  folders: ReadonlyArray<WorkspaceFolderLike>
+): boolean {
+  return !matchesAnyWorkspaceFolder(cwd, folders)
+}
+
+/**
+ * Picker option list given the cross-workspace flag. Cross → 2 options
+ * (Internal / External). Same-workspace → 3 options (Internal / External /
+ * Anthropic).
+ */
+export function pickerOptions(crossWorkspace: boolean): ReadonlyArray<ResumeMode> {
+  return crossWorkspace ? ['internal', 'external'] : ['internal', 'external', 'anthropic']
+}
+
+/**
+ * Decide what the resume-session command should do for the given input.
+ *
+ * The three user-named scenarios:
+ *   A) `defaultMode === 'ask'` + cross-workspace  → picker with 2 options
+ *   B) `defaultMode === 'ask'` + same-workspace   → picker with 3 options
+ *   C) `defaultMode === 'anthropic'` + same-workspace → direct anthropic open
+ *
+ * Bonus:
+ *   D) `defaultMode === 'anthropic'` + cross-workspace → fallback picker
+ *      (2 options) — the user pre-configured anthropic but the session can't
+ *      resolve there; fall back to terminal flavor instead of silently
+ *      reverting one of internal/external for them.
+ *
+ * Terminal defaults (`internal` / `external`) always dispatch directly — they
+ * do not care about workspace match.
+ */
+export function decideResume(input: {
+  defaultMode: DefaultTerminalMode
+  cwd: string | null | undefined
+  folders: ReadonlyArray<WorkspaceFolderLike>
+}): ResumeDecision {
+  const cross = isCrossWorkspace(input.cwd, input.folders)
+
+  if (input.defaultMode === 'internal' || input.defaultMode === 'external') {
+    return { kind: 'direct', mode: input.defaultMode }
+  }
+
+  if (input.defaultMode === 'anthropic') {
+    if (cross) {
+      return {
+        kind: 'fallback-picker',
+        options: pickerOptions(true),
+        reason: 'cross-workspace',
+      }
+    }
+    return { kind: 'direct', mode: 'anthropic' }
+  }
+
+  // defaultMode === 'ask' — picker with 2 or 3 options
+  return { kind: 'picker', options: pickerOptions(cross) }
+}

--- a/packages/vscode-extension/src/test/suite/commands.test.ts
+++ b/packages/vscode-extension/src/test/suite/commands.test.ts
@@ -33,4 +33,18 @@ suite('Command Registration Suite', () => {
       'claudeSessions.openPreviewToSide must be registered for the editor title preview action'
     )
   })
+
+  // GUARD: claudeSessions.resumeSession is the single entry point for resuming
+  // sessions (3-way picker: internal terminal / external terminal / Claude Code
+  // extension). Discussion #159 — M2 integrated picker. If this command is lost
+  // in a squash merge, all three "open session" paths break with "command not
+  // found" at click time.
+  test('claudeSessions.resumeSession command is registered', async function () {
+    await ensureExtensionActive(this)
+    const commands = await vscode.commands.getCommands(true)
+    assert.ok(
+      commands.includes('claudeSessions.resumeSession'),
+      'claudeSessions.resumeSession must be registered — the 3-way picker (internal/external/anthropic) for discussion #159 depends on it'
+    )
+  })
 })

--- a/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
+++ b/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
@@ -1,0 +1,310 @@
+import * as assert from 'assert'
+import {
+  decideResume,
+  matchesAnyWorkspaceFolder,
+  normalizeWorkspacePath,
+  type DefaultTerminalMode,
+  type ResumeDecision,
+  type WorkspaceFolderLike,
+} from '../../lib/crossWorkspace'
+
+// Pure-function unit tests for the resume-mode decision flow. Runs inside the
+// standard `pnpm test` electron host alongside integration suites — same
+// runner, same convention, single CI signal. No vscode API is touched, so the
+// failure surface is the logic alone (not the IDE harness).
+//
+// Discussion #159 — 3-way picker (Internal / External / Claude Code Extension).
+// The user explicitly asked for three named scenarios to be locked down with
+// dedicated tests: 2-option picker, 3-option picker, direct anthropic open.
+suite('crossWorkspace Suite', () => {
+  const folder = (fsPath: string): WorkspaceFolderLike => ({ uri: { fsPath } })
+
+  suite('normalizeWorkspacePath', () => {
+    test('lowercases and converts backslashes', () => {
+      assert.strictEqual(normalizeWorkspacePath('C:\\Users\\A\\Project'), 'c:/users/a/project')
+    })
+
+    test('leaves an already-normalized posix path unchanged (modulo case)', () => {
+      assert.strictEqual(normalizeWorkspacePath('/users/a/project'), '/users/a/project')
+    })
+
+    test('empty string stays empty', () => {
+      assert.strictEqual(normalizeWorkspacePath(''), '')
+    })
+  })
+
+  suite('matchesAnyWorkspaceFolder', () => {
+    test('null cwd never matches', () => {
+      assert.strictEqual(matchesAnyWorkspaceFolder(null, [folder('/a')]), false)
+    })
+
+    test('undefined cwd never matches', () => {
+      assert.strictEqual(matchesAnyWorkspaceFolder(undefined, [folder('/a')]), false)
+    })
+
+    test('empty cwd never matches', () => {
+      assert.strictEqual(matchesAnyWorkspaceFolder('', [folder('/a')]), false)
+    })
+
+    test('empty folders never matches', () => {
+      assert.strictEqual(matchesAnyWorkspaceFolder('/a', []), false)
+    })
+
+    test('exact path match returns true', () => {
+      assert.strictEqual(
+        matchesAnyWorkspaceFolder('/users/a/project', [folder('/users/a/project')]),
+        true
+      )
+    })
+
+    test('case-insensitive match (Windows drive letter)', () => {
+      assert.strictEqual(
+        matchesAnyWorkspaceFolder('C:\\Users\\A\\Project', [folder('c:/users/a/project')]),
+        true
+      )
+    })
+
+    test('multi-root: returns true ONLY when folders[0] matches (active workspace)', () => {
+      assert.strictEqual(
+        matchesAnyWorkspaceFolder('/users/a/project', [
+          folder('/users/a/project'),
+          folder('/users/a/other'),
+        ]),
+        true
+      )
+    })
+
+    test('multi-root: returns false when folders[1+] matches but folders[0] does not (anthropic cannot resolve)', () => {
+      assert.strictEqual(
+        matchesAnyWorkspaceFolder('/users/a/project', [
+          folder('/users/a/other'),
+          folder('/users/a/project'),
+        ]),
+        false
+      )
+    })
+
+    test('multi-root: returns false when no folder matches', () => {
+      assert.strictEqual(
+        matchesAnyWorkspaceFolder('/users/a/project', [
+          folder('/users/a/other'),
+          folder('/users/a/yet-another'),
+        ]),
+        false
+      )
+    })
+  })
+
+  // The three user-requested scenarios. Each owns its own suite so a failure
+  // in one path is named explicitly in the test report — no opaque single
+  // failure that conflates picker shape with direct-open dispatch.
+  suite('decideResume — scenario A: 2-option picker (cross-workspace, ask)', () => {
+    test('cross-workspace + defaultMode=ask → picker with 2 options', () => {
+      const decision: ResumeDecision = decideResume({
+        defaultMode: 'ask',
+        cwd: '/users/a/project',
+        folders: [folder('/users/a/other')],
+      })
+      assert.deepStrictEqual(decision, {
+        kind: 'picker',
+        options: ['internal', 'external'],
+      })
+    })
+
+    test('no folders open (cross) + defaultMode=ask → picker with 2 options', () => {
+      const decision = decideResume({
+        defaultMode: 'ask',
+        cwd: '/users/a/project',
+        folders: [],
+      })
+      assert.deepStrictEqual(decision, {
+        kind: 'picker',
+        options: ['internal', 'external'],
+      })
+    })
+
+    test('cwd null (cross) + defaultMode=ask → picker with 2 options', () => {
+      const decision = decideResume({
+        defaultMode: 'ask',
+        cwd: null,
+        folders: [folder('/users/a/project')],
+      })
+      assert.deepStrictEqual(decision, {
+        kind: 'picker',
+        options: ['internal', 'external'],
+      })
+    })
+  })
+
+  suite('decideResume — scenario B: 3-option picker (same-workspace, ask)', () => {
+    test('same-workspace + defaultMode=ask → picker with 3 options', () => {
+      const decision = decideResume({
+        defaultMode: 'ask',
+        cwd: '/users/a/project',
+        folders: [folder('/users/a/project')],
+      })
+      assert.deepStrictEqual(decision, {
+        kind: 'picker',
+        options: ['internal', 'external', 'anthropic'],
+      })
+    })
+
+    test('multi-root folders[0]-matches + defaultMode=ask → picker with 3 options', () => {
+      const decision = decideResume({
+        defaultMode: 'ask',
+        cwd: '/users/a/project',
+        folders: [folder('/users/a/project'), folder('/users/a/other')],
+      })
+      assert.deepStrictEqual(decision, {
+        kind: 'picker',
+        options: ['internal', 'external', 'anthropic'],
+      })
+    })
+
+    test('multi-root folders[1+]-matches-but-folders[0]-does-not + defaultMode=ask → picker with 2 options (cross)', () => {
+      const decision = decideResume({
+        defaultMode: 'ask',
+        cwd: '/users/a/project',
+        folders: [folder('/users/a/other'), folder('/users/a/project')],
+      })
+      assert.deepStrictEqual(decision, {
+        kind: 'picker',
+        options: ['internal', 'external'],
+      })
+    })
+  })
+
+  suite('decideResume — scenario C: direct anthropic open (no picker)', () => {
+    test('same-workspace + defaultMode=anthropic → direct anthropic open (no picker)', () => {
+      const decision = decideResume({
+        defaultMode: 'anthropic',
+        cwd: '/users/a/project',
+        folders: [folder('/users/a/project')],
+      })
+      assert.deepStrictEqual(decision, { kind: 'direct', mode: 'anthropic' })
+    })
+
+    test('Windows case-mismatched same-workspace + defaultMode=anthropic → direct anthropic', () => {
+      const decision = decideResume({
+        defaultMode: 'anthropic',
+        cwd: 'C:\\Users\\A\\Project',
+        folders: [folder('c:/users/a/project')],
+      })
+      assert.deepStrictEqual(decision, { kind: 'direct', mode: 'anthropic' })
+    })
+  })
+
+  suite('decideResume — bonus: cross-workspace + defaultMode=anthropic → fallback picker', () => {
+    test('cross-workspace + defaultMode=anthropic → fallback picker (2 options)', () => {
+      const decision = decideResume({
+        defaultMode: 'anthropic',
+        cwd: '/users/a/project',
+        folders: [folder('/users/a/other')],
+      })
+      assert.deepStrictEqual(decision, {
+        kind: 'fallback-picker',
+        options: ['internal', 'external'],
+        reason: 'cross-workspace',
+      })
+    })
+  })
+
+  suite('decideResume — direct internal / external (defaultMode skips picker)', () => {
+    const internalSameWorkspace: ResumeDecision = {
+      kind: 'direct',
+      mode: 'internal',
+    }
+    const externalSameWorkspace: ResumeDecision = {
+      kind: 'direct',
+      mode: 'external',
+    }
+
+    test('defaultMode=internal + same-workspace → direct internal', () => {
+      assert.deepStrictEqual(
+        decideResume({
+          defaultMode: 'internal',
+          cwd: '/users/a/project',
+          folders: [folder('/users/a/project')],
+        }),
+        internalSameWorkspace
+      )
+    })
+
+    test('defaultMode=internal + cross-workspace → direct internal (terminal modes never care about cwd match)', () => {
+      assert.deepStrictEqual(
+        decideResume({
+          defaultMode: 'internal',
+          cwd: '/users/a/project',
+          folders: [folder('/users/a/other')],
+        }),
+        internalSameWorkspace
+      )
+    })
+
+    test('defaultMode=external + same-workspace → direct external', () => {
+      assert.deepStrictEqual(
+        decideResume({
+          defaultMode: 'external',
+          cwd: '/users/a/project',
+          folders: [folder('/users/a/project')],
+        }),
+        externalSameWorkspace
+      )
+    })
+
+    test('defaultMode=external + cross-workspace → direct external', () => {
+      assert.deepStrictEqual(
+        decideResume({
+          defaultMode: 'external',
+          cwd: '/users/a/project',
+          folders: [folder('/users/a/other')],
+        }),
+        externalSameWorkspace
+      )
+    })
+  })
+
+  // The two invariants below are stronger than any individual scenario test:
+  // they enumerate every possible defaultMode value and assert that no input
+  // combination can ever route a cross-workspace session to a direct anthropic
+  // dispatch or to a picker that even offers anthropic as an option. If a
+  // future refactor introduces a regression (e.g., dropping the cross-workspace
+  // check in `decideResume`), these tests fail loudly.
+  suite('decideResume — INVARIANTS (cross-workspace never reaches anthropic)', () => {
+    const crossFolders = [folder('/users/a/other')]
+    const sessionCwd = '/users/a/project'
+    const allDefaultModes: DefaultTerminalMode[] = ['ask', 'internal', 'external', 'anthropic']
+
+    test('INVARIANT 1 — cross-workspace + ANY defaultMode → never dispatches anthropic directly (would load empty session)', () => {
+      for (const defaultMode of allDefaultModes) {
+        const decision = decideResume({ defaultMode, cwd: sessionCwd, folders: crossFolders })
+        if (decision.kind === 'direct') {
+          assert.notStrictEqual(
+            decision.mode,
+            'anthropic',
+            `REGRESSION: defaultMode='${defaultMode}' + cross-workspace produced { kind: 'direct', mode: 'anthropic' }. ` +
+              `This would call vscode://anthropic.claude-code/open?session=... whose handler resolves against the active workspace cwd ` +
+              `(which does NOT match this session) → empty session opens.`
+          )
+        }
+      }
+    })
+
+    test('INVARIANT 2 — cross-workspace + ANY defaultMode → picker options never include anthropic (user cannot opt into empty session)', () => {
+      for (const defaultMode of allDefaultModes) {
+        const decision = decideResume({ defaultMode, cwd: sessionCwd, folders: crossFolders })
+        if (decision.kind === 'picker' || decision.kind === 'fallback-picker') {
+          assert.ok(
+            !decision.options.includes('anthropic'),
+            `REGRESSION: defaultMode='${defaultMode}' + cross-workspace produced a picker with anthropic in options=${JSON.stringify(decision.options)}. ` +
+              `User could pick anthropic and trigger an empty-session open.`
+          )
+        }
+      }
+    })
+
+    // INVARIANT 3/4 (null cwd + empty folders) were covered transitively by
+    // INVARIANT 1/2's defaultMode enumeration on top of the matchesAnyWorkspaceFolder
+    // null/empty unit tests — removed as redundant.
+  })
+})


### PR DESCRIPTION
## Summary

Implements **M2 (3-way integrated picker)** from [discussion #159 comment 17032358](https://github.com/es6kr/claude-code-sessions/discussions/159#discussioncomment-17032358). External user `@rpielanen-bevk-dev` confirmed preference for M2 over M1 in [reply 17051387](https://github.com/es6kr/claude-code-sessions/discussions/159#discussioncomment-17051387).

The existing `claudeSessions.resumeSession` command's Quick Pick now offers a third option, **`$(window) Claude Code Extension`**, alongside Internal/External Terminal. Selecting it opens the session inside the official `anthropic.claude-code` extension's webview tab via its registered URI handler (`vscode://anthropic.claude-code/open?session=<id>`).

This rejects M1 (a separate `resumeInClaudeCodeExtension` command + its own context-menu entry) in favor of a single entry point — UX consistency and the `defaultTerminalMode` setting can fully skip the picker for any of the three modes.

## Why M2 over M1

- **Single entry point** — one menu item ("Resume Session") handles all three modes; users don't need to learn a second command.
- **`defaultTerminalMode` becomes more useful** — its enum now includes `"anthropic"`, so users who always want the Claude Code extension can skip the picker entirely.
- **Future-proof** — adding more open targets (e.g., remote container) is one entry in the Quick Pick array, not a new command + menu entry pair.

## Issue 1 (cross-workspace) — C1 conservative default

The official `anthropic.claude-code` extension resolves sessions against the **active workspace cwd**, so sessions from other working directories cannot be inlined. This PR ships option **C1 (warn + Open Anyway / Cancel)** as the conservative default:

```
Session belongs to "/path/to/other-project". The Claude Code extension only
resumes sessions for the current workspace ("/path/to/current"). [Open Anyway] [Cancel]
```

Options C2 (auto-open folder in new window) and C3 (upstream URI handler `cwd` param) remain open for follow-up if needed — see [comment 17032357](https://github.com/es6kr/claude-code-sessions/discussions/159#discussioncomment-17032357).

## Changes

| File | Change |
|------|--------|
| `packages/vscode-extension/package.json` | `defaultTerminalMode` enum gains `"anthropic"`; description extended |
| `packages/vscode-extension/src/extension.ts` | `claudeSessions.resumeSession` handler: 3-way picker + anthropic branch (sessionId validation → extension presence detection → cross-workspace warning → URI handler) |
| `packages/vscode-extension/src/test/suite/commands.test.ts` | Regression guard: `claudeSessions.resumeSession` must remain registered (prevents future squash merges from silently dropping the 3-way picker entry point) |

## Test Plan

- [x] Right-click a session → `Resume Session` → Quick Pick shows **3 options** (Internal Terminal / External Terminal / Claude Code Extension)
- [x] Choose `Claude Code Extension` for a **same-workspace session** → `anthropic.claude-code` opens the webview tab with the session loaded
- [x] Choose `Claude Code Extension` for a **cross-workspace session** → fall back to Internal/External Terminal (`defaultTerminalMode` skips picker; otherwise 2-option Internal/External picker shown)
- [x] On a machine without `anthropic.claude-code` installed → `Install` / `Cancel` prompt; selecting `Install` triggers `workbench.extensions.installExtension`
- [x] Set `claudeSessions.defaultTerminalMode` to `"anthropic"` → resumeSession opens directly without showing the picker
- [x] Set `claudeSessions.defaultTerminalMode` to `"internal"` or `"external"` → existing terminal behavior preserved
- [x] CI green: build + test + lint (verified run #27175201320 SUCCESS on 9dd66cd (quick wins applied); test ubuntu/windows + e2e all green)

## Verification commands

```sh
# Build only the affected extension
cd packages/vscode-extension && pnpm build:extension

# Lint
pnpm lint

# Manual install for verification
/vsix   # rebuild + reinstall via vsix skill
```

## Trade-offs

- **Picker now has 3 options instead of 2** — extra cognitive step for users who only ever use terminal. Mitigated by `defaultTerminalMode='internal'|'external'` skipping the picker entirely.
- **Cross-workspace sessions still cannot be inlined** — addressed by C1 warning; auto-folder-open (C2) deferred until verified that `anthropic.claude-code` auto-resumes the session after `vscode.openFolder`.

## Related

- Discussion: [#159 — Please add option to open session in Claude Code VS Extension, next to Terminal](https://github.com/es6kr/claude-code-sessions/discussions/159)
- Reply confirming M2: [discussioncomment-17051387](https://github.com/es6kr/claude-code-sessions/discussions/159#discussioncomment-17051387)
- Issue 1 (cross-workspace) discussion: [comment 17032357](https://github.com/es6kr/claude-code-sessions/discussions/159#discussioncomment-17032357)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "anthropic" resume mode to open sessions directly in the official Claude Code extension, prompting/installing and falling back to a picker when workspace conditions require.

* **Configuration**
  * Terminal mode settings now include the "anthropic" option for session resumption.

* **Tests**
  * Added unit tests for cross-workspace resume decisions and a regression test ensuring the resume command remains registered.

* **Documentation**
  * Added a rule prohibiting hardcoded IDE URI schemes.

* **Chores**
  * Extension version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





