### PR TITLE
ci: add main semantic-release workflow + .releaserc.json (replace release-please for main)

### DIFF
--- a/.github/workflows/main-semantic-release.yml
+++ b/.github/workflows/main-semantic-release.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '24'  # release-vscode.yml과 일관 — semantic-release npx 실행 환경 동일
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4  # @semantic-release/exec prepareCmd로 pnpm install --lockfile-only 실행 위해 필요
 
       - name: Install semantic-release + plugins
         run: |
@@ -31,6 +34,7 @@ jobs:
             semantic-release@^24 \
             @semantic-release/commit-analyzer \
             @semantic-release/release-notes-generator \
+            @semantic-release/exec \
             @semantic-release/npm \
             @semantic-release/git \
             @semantic-release/github

--- a/.github/workflows/main-semantic-release.yml
+++ b/.github/workflows/main-semantic-release.yml
@@ -1,0 +1,41 @@
+name: main semantic-release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: production-vscode  # required reviewer 승인 후 진행
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}  # release-vscode workflow downstream trigger 위해 PAT 사용
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install semantic-release + plugins
+        run: |
+          npm install --no-save \
+            semantic-release@^24 \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator \
+            @semantic-release/npm \
+            @semantic-release/git \
+            @semantic-release/github
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,33 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "feat", "release": "patch" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "chore", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "ci", "release": "patch" },
+          { "breaking": true, "release": "minor" }
+        ]
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/npm", { "npmPublish": false, "pkgRoot": "packages/vscode-extension" }],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["packages/vscode-extension/package.json"],
+        "message": "chore(release): vscode-v${nextRelease.version} [skip ci]"
+      }
+    ],
+    "@semantic-release/github"
+  ],
+  "tagFormat": "vscode-v${version}"
+}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,19 +11,17 @@
           { "type": "perf", "release": "patch" },
           { "type": "chore", "release": "patch" },
           { "type": "refactor", "release": "patch" },
-          { "type": "docs", "release": "patch" },
-          { "type": "test", "release": "patch" },
-          { "type": "ci", "release": "patch" },
           { "breaking": true, "release": "minor" }
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    ["@semantic-release/release-notes-generator", { "preset": "angular" }],
+    ["@semantic-release/exec", { "prepareCmd": "pnpm install --lockfile-only" }],
     ["@semantic-release/npm", { "npmPublish": false, "pkgRoot": "packages/vscode-extension" }],
     [
       "@semantic-release/git",
       {
-        "assets": ["packages/vscode-extension/package.json"],
+        "assets": ["packages/vscode-extension/package.json", "pnpm-lock.yaml"],
         "message": "chore(release): vscode-v${nextRelease.version} [skip ci]"
       }
     ],


### PR DESCRIPTION
## Summary

Replaces `release-please` for the `main` branch stable channel with `semantic-release/semantic-release` and adds GitHub Environment protection (`production-vscode`) so every stable publish requires explicit human approval.

The previous attempt to publish `vscode-v0.4.9` manually (push tag only, no `package.json` bump) failed: the `release-vscode` workflow built the vsix at `0.4.8` while Open VSX expected `0.4.9` (run [#27192111445](https://github.com/es6kr/claude-code-sessions/actions/runs/27192111445)). The stale `vscode-v0.4.9` tag has already been deleted. This PR introduces the workflow that produces the correct tag + `package.json` bump in a single, reviewed step.

`ovsx-beta` keeps using `release-please-vscode-beta` for now; its migration to `semantic-release` lands in a separate PR after this stable publish succeeds.

## Why semantic-release (vs current release-please)

Several quirks of `googleapis/release-please-action@v4` made base-version pinning fragile in the beta channel (see `claude-code-sessions.md` "release-please-action quirks"):

- `release-as` action input and config-file `release-as` field are both ignored
- `versioning-strategy: "prerelease"` alone does not block conventional-commits base bumps
- The documented workaround (commit body `Release-As:` footer) is not recognized on merge commits
- Workflow needs ~70 lines of `jq` inject + amend+force-push maintenance on the release PR head

`semantic-release` collapses these into a single `releaseRules` map and a clean push-driven flow. The trade-off is that conventional-commit semantics are partially flattened (every type → `patch`, `breaking` → `minor`), which matches the use case (counter-only beta increments).

## Changes

| File | Change |
|------|--------|
| `.github/workflows/main-semantic-release.yml` | New workflow on `push: branches: [main]` + `workflow_dispatch`. Installs `semantic-release@^24` + plugins, runs the release. Pinned to `environment: production-vscode` so the run pauses for a required reviewer. Uses `secrets.RELEASE_PLEASE_PAT` (same PAT as the beta pipeline) so downstream `release-vscode.yml` is triggered by the new tag (`GITHUB_TOKEN` would block that) |
| `.releaserc.json` | New `branches: ["main"]` config. `releaseRules` map flattens all commit types to `patch` and `breaking` to `minor` per the user-confirmed trade-off. `@semantic-release/npm` (`npmPublish: false`, `pkgRoot: packages/vscode-extension`) bumps the extension's `package.json` only. `@semantic-release/git` commits the bump back to `main` with `[skip ci]`. `@semantic-release/github` creates the tag + GitHub Release. `tagFormat: "vscode-v${version}"` keeps the existing tag scheme |

## Trade-offs

- **Conventional-commits semantics partially flattened.** `feat:` no longer bumps minor; only `breaking` does. This matches the explicit user policy (counter-only stable increments unless an intentional minor signal is sent) but breaks the default conventional-commits contract.
- **`main` push triggers a self-write.** `@semantic-release/git` pushes the version-bump commit back to `main`. The `[skip ci]` marker stops the workflow re-running on its own commit, but the chore commit will appear in `main` history every release. Acceptable cost for keeping `package.json` and the tag in sync.
- **`environment: production-vscode` adds a manual gate.** Every stable release blocks on a required-reviewer approval. Slower than fully automated publish, but it's the safety net the user explicitly requested after the previous manual-tag failure.
- **PAT instead of `GITHUB_TOKEN`.** Required because `GITHUB_TOKEN`-driven pushes cannot trigger other workflows (GitHub infinite-loop guard). Reuses `secrets.RELEASE_PLEASE_PAT` — same scope as the existing beta pipeline.
- **`ovsx-beta` left on `release-please` in this PR.** Scope is intentionally narrowed to `main` so the failed `vscode-v0.4.9` publish can be replayed first. The beta migration follows in a separate PR once stable is confirmed.

## Test Plan

- [x] `[general]` CI green on this PR (workflow file syntax + JSON validity check at minimum)
- [ ] `[post-merge]` After merge, `main-semantic-release` workflow (tracking: GitHub Actions run on main after merge) run starts and pauses with status "Waiting" on the `production-vscode` environment
- [ ] `[post-merge]` DrumRobot approves (tracking: production-vscode environment deployment log) the deployment in GitHub UI → semantic-release proceeds
- [ ] `[post-merge]` Tag `vscode-v0.4.9` is created (tracking: gh api repos/.../tags) on the merge commit (verify via `gh api repos/es6kr/claude-code-sessions/tags`)
- [ ] `[post-merge]` `packages/vscode-extension/package.json` `version` is bumped to `0.4.9` via the chore release commit on `main` (with `[skip ci]`)
- [ ] `[post-merge]` GitHub Release `vscode-v0.4.9` is created (prerelease=false, generated changelog)
- [ ] `[post-merge]` `release-vscode.yml` is triggered (tracking: gh run list --workflow release-vscode.yml) by the new tag (PAT-driven push)
- [ ] `[post-merge]` Open VSX `claude-sessions@0.4.9` published (verify via `curl https://open-vsx.org/api/es6kr/claude-sessions/0.4.9`)
- [ ] `[post-merge]` No regression on existing `release-please-vscode-beta` workflow for `ovsx-beta` (left untouched in this PR)

## Related

- Failed run: [#27192111445](https://github.com/es6kr/claude-code-sessions/actions/runs/27192111445)
- Follow-up: `ovsx-beta` migration to `semantic-release` in a separate PR after this stable release succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated release pipeline using semantic versioning for the main branch.
  * Automatic release generation with version bumping triggered on pushes to main, using commit types to determine version increments.
  * Auto-generated release notes published to npm for the VS Code extension package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
