### PR TITLE
chore(release): vscode-v0.4.9

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "claude-sessions",
   "displayName": "Claude Code Sessions",
   "description": "Manage Claude Code sessions from VS Code sidebar",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "publisher": "es6kr",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Manual bump for v0.4.9 publish. Recovers from the failed v0.4.9 attempts:

- run [#27192111445](https://github.com/es6kr/claude-code-sessions/actions/runs/27192111445) — manual tag push, no `package.json` bump → vsix 0.4.8 / Open VSX expected 0.4.9 mismatch (tag deleted)
- run [#27195990797](https://github.com/es6kr/claude-code-sessions/actions/runs/27195990797) — semantic-release on main saw last reachable stable as `vscode-v0.4.7` (because `vscode-v0.4.8` points to an ovsx-beta commit unreachable from main) → tried to retag 0.4.8 → `fatal: tag already exists`

This PR bumps `packages/vscode-extension/package.json` from 0.4.8 → 0.4.9. After merge, push tag `vscode-v0.4.9` manually to trigger `release-vscode.yml` → Open VSX `claude-sessions@0.4.9` publish. The `[skip ci]` marker on the chore commit prevents the new `main-semantic-release` workflow from re-entering the same 0.4.8 retag failure on this commit.

Follow-up: align `vscode-v0.4.8` tag to a main-reachable commit (or pin `@semantic-release/git` `tag` plugin behavior) so the next stable bump via `main-semantic-release` resolves `vscode-v0.4.9` → patch → `vscode-v0.4.10` cleanly.

## Test Plan

- [x] `[general]` `package.json` version bumped 0.4.8 → 0.4.9
- [x] `[general]` `pnpm install --frozen-lockfile` succeeds (lockfile + bumped version compatible)
- [ ] `[post-merge]` After merge, push tag `vscode-v0.4.9` to main HEAD (tracking: gh api repos/.../tags)
- [ ] `[post-merge]` `release-vscode.yml` triggered by new tag (tracking: gh run list --workflow release-vscode.yml)
- [ ] `[post-merge]` Open VSX `claude-sessions@0.4.9` published (verify via curl https://open-vsx.org/api/es6kr/claude-sessions/0.4.9)