### PR TITLE
ci: add npm-semantic-release workflow + .releaserc-npm.json

### DIFF
--- a/.github/workflows/main-semantic-release.yml
+++ b/.github/workflows/main-semantic-release.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Serialize with npm-semantic-release.yml on the same push: main event.
+# Two semantic-release runs sharing main HEAD must not race on git push.
+concurrency:
+  group: semantic-release-main
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write
@@ -12,21 +18,24 @@ permissions:
 
 jobs:
   release:
+    # Skip release on the commit semantic-release itself pushed back (loop prevention).
+    # `[skip release]` is project-narrow signal — does NOT block CI / e2e / dependabot workflows.
+    if: ${{ !contains(github.event.head_commit.message, '[skip release]') }}
     runs-on: ubuntu-latest
-    environment: production-vscode  # required reviewer 승인 후 진행
+    environment: production-vscode # required reviewer 승인 후 진행
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_PAT }}  # release-vscode workflow downstream trigger 위해 PAT 사용
+          token: ${{ secrets.RELEASE_PLEASE_PAT }} # release-vscode workflow downstream trigger 위해 PAT 사용
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'  # release-vscode.yml과 일관 — semantic-release npx 실행 환경 동일
+          node-version: '24' # release-vscode.yml과 일관 — semantic-release npx 실행 환경 동일
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4  # @semantic-release/exec prepareCmd로 pnpm install --lockfile-only 실행 위해 필요
+        uses: pnpm/action-setup@v4 # @semantic-release/exec prepareCmd로 pnpm install --lockfile-only 실행 위해 필요
 
       - name: Install semantic-release + plugins
         run: |

--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -1,8 +1,20 @@
 name: npm semantic-release
 
+# Versioning strategy: stable-only channel on the main branch.
+# - Baseline: highest matching git tag for tagFormat `v${version}` (excluding vscode-v tags).
+# - Commit-analyzer scope filter (.releaserc-npm.json) blocks `(vscode)`-scoped commits so vscode-only work does NOT bump npm packages.
+# - Tag push (`v[0-9]*`) triggers downstream publish-npm.yml (npm publish for @claude-sessions/core/ui/web/mcp).
+# - prerelease channel: not configured here. Beta releases live on ovsx-beta / beta branches with their own configs.
+
 on:
   push: { branches: [main] }
   workflow_dispatch:
+
+# Serialize with main-semantic-release.yml (vscode) on the same push: main event.
+# Two semantic-release runs sharing main HEAD must not race on git push.
+concurrency:
+  group: semantic-release-main
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -11,6 +23,9 @@ permissions:
 
 jobs:
   release:
+    # Skip release on the commit semantic-release itself pushed back (loop prevention).
+    # `[skip release]` is project-narrow signal — does NOT block CI / e2e / dependabot workflows.
+    if: ${{ !contains(github.event.head_commit.message, '[skip release]') }}
     runs-on: ubuntu-latest
     environment: production-npm # required reviewer approval before publish
     steps:

--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -1,0 +1,43 @@
+name: npm semantic-release
+
+on:
+  push: { branches: [main] }
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: production-npm # required reviewer approval before publish
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_PAT }} # PAT enables downstream publish-npm.yml trigger on tag push
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24' # consistent with main-semantic-release.yml + release-vscode.yml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4 # needed by @semantic-release/exec prepareCmd (pnpm version + pnpm install --lockfile-only)
+
+      - name: Install semantic-release + plugins
+        run: |
+          npm install --no-save \
+            semantic-release@^24 \
+            @semantic-release/commit-analyzer \
+            @semantic-release/release-notes-generator \
+            @semantic-release/exec \
+            @semantic-release/git \
+            @semantic-release/github
+
+      - name: Run semantic-release (npm config)
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
+        run: npx semantic-release --extends ./.releaserc-npm.json

--- a/.releaserc-npm.json
+++ b/.releaserc-npm.json
@@ -1,0 +1,48 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          { "type": "feat", "scope": "vscode", "release": false },
+          { "type": "fix", "scope": "vscode", "release": false },
+          { "type": "perf", "scope": "vscode", "release": false },
+          { "type": "feat", "release": "patch" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "chore", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "ci", "release": "patch" },
+          { "breaking": true, "release": "minor" }
+        ]
+      }
+    ],
+    ["@semantic-release/release-notes-generator", { "preset": "angular" }],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "pnpm version ${nextRelease.version} --no-git-tag-version --allow-same-version && pnpm install --lockfile-only"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "package.json",
+          "packages/core/package.json",
+          "packages/ui/package.json",
+          "packages/web/package.json",
+          "packages/mcp/package.json",
+          "pnpm-lock.yaml"
+        ],
+        "message": "chore(release): v${nextRelease.version} [skip ci]"
+      }
+    ],
+    "@semantic-release/github"
+  ],
+  "tagFormat": "v${version}"
+}

--- a/.releaserc-npm.json
+++ b/.releaserc-npm.json
@@ -9,6 +9,11 @@
           { "type": "feat", "scope": "vscode", "release": false },
           { "type": "fix", "scope": "vscode", "release": false },
           { "type": "perf", "scope": "vscode", "release": false },
+          { "type": "chore", "scope": "vscode", "release": false },
+          { "type": "refactor", "scope": "vscode", "release": false },
+          { "type": "docs", "scope": "vscode", "release": false },
+          { "type": "test", "scope": "vscode", "release": false },
+          { "type": "ci", "scope": "vscode", "release": false },
           { "type": "feat", "release": "patch" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },
@@ -25,7 +30,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "pnpm version ${nextRelease.version} --no-git-tag-version --allow-same-version && pnpm install --lockfile-only"
+        "prepareCmd": "pnpm version ${nextRelease.version} --no-git-tag-version --allow-same-version && pnpm install --lockfile-only --frozen-lockfile"
       }
     ],
     [
@@ -39,7 +44,7 @@
           "packages/mcp/package.json",
           "pnpm-lock.yaml"
         ],
-        "message": "chore(release): v${nextRelease.version} [skip ci]"
+        "message": "chore(release): v${nextRelease.version} [skip release]"
       }
     ],
     "@semantic-release/github"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,15 @@
       {
         "preset": "angular",
         "releaseRules": [
+          { "type": "feat", "scope": "web", "release": false },
+          { "type": "fix", "scope": "web", "release": false },
+          { "type": "perf", "scope": "web", "release": false },
+          { "type": "feat", "scope": "mcp", "release": false },
+          { "type": "fix", "scope": "mcp", "release": false },
+          { "type": "perf", "scope": "mcp", "release": false },
+          { "type": "feat", "scope": "ui", "release": false },
+          { "type": "fix", "scope": "ui", "release": false },
+          { "type": "perf", "scope": "ui", "release": false },
           { "type": "feat", "release": "patch" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,12 +9,27 @@
           { "type": "feat", "scope": "web", "release": false },
           { "type": "fix", "scope": "web", "release": false },
           { "type": "perf", "scope": "web", "release": false },
+          { "type": "chore", "scope": "web", "release": false },
+          { "type": "refactor", "scope": "web", "release": false },
+          { "type": "docs", "scope": "web", "release": false },
+          { "type": "test", "scope": "web", "release": false },
+          { "type": "ci", "scope": "web", "release": false },
           { "type": "feat", "scope": "mcp", "release": false },
           { "type": "fix", "scope": "mcp", "release": false },
           { "type": "perf", "scope": "mcp", "release": false },
+          { "type": "chore", "scope": "mcp", "release": false },
+          { "type": "refactor", "scope": "mcp", "release": false },
+          { "type": "docs", "scope": "mcp", "release": false },
+          { "type": "test", "scope": "mcp", "release": false },
+          { "type": "ci", "scope": "mcp", "release": false },
           { "type": "feat", "scope": "ui", "release": false },
           { "type": "fix", "scope": "ui", "release": false },
           { "type": "perf", "scope": "ui", "release": false },
+          { "type": "chore", "scope": "ui", "release": false },
+          { "type": "refactor", "scope": "ui", "release": false },
+          { "type": "docs", "scope": "ui", "release": false },
+          { "type": "test", "scope": "ui", "release": false },
+          { "type": "ci", "scope": "ui", "release": false },
           { "type": "feat", "release": "patch" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },
@@ -31,7 +46,7 @@
       "@semantic-release/git",
       {
         "assets": ["packages/vscode-extension/package.json", "pnpm-lock.yaml"],
-        "message": "chore(release): vscode-v${nextRelease.version} [skip ci]"
+        "message": "chore(release): vscode-v${nextRelease.version} [skip release]"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary

Add npm semantic-release automation to match the vscode pipeline.

- **`.github/workflows/npm-semantic-release.yml`** — main push triggers semantic-release with `production-npm` environment (required reviewer approval). Uses `RELEASE_PLEASE_PAT` so the resulting `v*` tag push triggers the downstream `publish-npm.yml`.
- **`.releaserc-npm.json`** — `tagFormat=v${version}`. `@semantic-release/exec` runs `pnpm version` which fires the root `scripts.version` hook to sync `core`, `ui`, `web`, `mcp`. `@semantic-release/git` commits the 5 package files + lockfile. npm publish itself stays in `publish-npm.yml` (tag trigger) — semantic-release handles only version bump + tag push.
- **`.releaserc.json` (vscode)** — adds scope filter so `feat(web|mcp|ui): ...` no longer triggers a vscode bump. `core` scope keeps bumping both (per the project decision: core changes affect vscode too).

## Why

vscode is fully automated by `main-semantic-release.yml`. npm still requires manual `pnpm version` + tag push. This PR adds the missing parity so npm publish chain runs from the same `push: main` trigger as vscode.

## Coexistence with `main-semantic-release.yml`

| Workflow | tagFormat | Environment | pkgRoot scope |
|----------|-----------|-------------|---------------|
| main-semantic-release | `vscode-v${version}` | `production-vscode` | packages/vscode-extension |
| npm-semantic-release | `v${version}` | `production-npm` | core + ui + web + mcp (via root scripts.version) |

Distinct tagFormat and environment prevent any race/clash. Both workflows trigger on the same `push: main`, but each only produces its own tag.

## Test plan

- [ ] **[post-merge]** PR merge → `npm-semantic-release` workflow triggers (tracking: fix_plan.md `[BLOCKED]` `[REVIEW_FEEDBACK]` PR #177 entry)
- [ ] **[post-merge]** `production-npm` environment shows "Waiting for approval" with DrumRobot listed (tracking: same fix_plan entry)
- [ ] **[post-merge]** DrumRobot approves → semantic-release runs → patches package.json files + commits `chore(release): v0.4.10 [skip ci]` + pushes tag `v0.4.10` (tracking: same fix_plan entry)
- [ ] **[post-merge]** Tag push triggers `publish-npm.yml` (tracking: same fix_plan entry)
- [ ] **[post-merge]** Verify all 4 packages publish 0.4.10 to npm: (tracking: same fix_plan entry)
  ```bash
  for p in "@claude-sessions/core" "@claude-sessions/ui" "@claude-sessions/web" "claude-sessions-mcp"; do
    npm view "$p" version
  done
  # expected: 0.4.10
  ```
- [ ] **[post-merge]** Verify `main-semantic-release` (vscode) does NOT bump on the same push (current main commits are `ci:` scope-less → both still bump, expected behavior for unscoped commits) (tracking: same fix_plan entry)

## Follow-up (separate PRs)

- The fix from PR #166 (`fix(web): normalize Content shapes`) is currently only on the `beta` branch. Backport to `main` will be decided separately and will land before the first 0.4.10 publish.

## Pre-merge setup

After this PR is approved but before merging, create the GitHub environment:

```bash
gh api -X PUT repos/es6kr/claude-code-sessions/environments/production-npm \
  -F "reviewers[][type]=User" \
  -F "reviewers[][id]=819969"  # DrumRobot
```

(Same shape as `production-vscode`.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated semantic versioning and release management for npm packages with scope-based rules to prevent unintended releases.
  * Release notes and tags will be generated automatically and published.
  * Commits can opt out of releases via a special commit message marker.
  * Updated release process to commit updated package metadata and lockfile changes during publish.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
