### PR TITLE
fix(core): deduplicate messages by uuid in readSession (#137 phase 3)

### DIFF
--- a/packages/core/src/__tests__/crud.test.ts
+++ b/packages/core/src/__tests__/crud.test.ts
@@ -563,3 +563,181 @@ describe('updateMessageContent', () => {
     expect((result as { error?: string }).error).toBe('Message not found')
   })
 })
+
+describe('readSession dedup (Issue #137 Phase 3)', () => {
+  let tempDir: string
+  let projectDir: string
+  const projectName = '-Users-test-readsession-dedup'
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-session-dedup-'))
+    projectDir = path.join(tempDir, projectName)
+    await fs.mkdir(projectDir, { recursive: true })
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  const writeMessages = async (sessionId: string, messages: unknown[]) => {
+    const filePath = path.join(projectDir, `${sessionId}.jsonl`)
+    await fs.writeFile(filePath, messages.map((m) => JSON.stringify(m)).join('\n') + '\n')
+  }
+
+  it('should keep all messages when there are no duplicate uuids', async () => {
+    const sessionId = 'test-session'
+    await writeMessages(sessionId, [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        timestamp: '2025-12-19T01:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'A' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-1',
+        parentUuid: 'user-1',
+        timestamp: '2025-12-19T01:00:01.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'B' }] },
+      },
+    ])
+
+    const messages = await Effect.runPromise(readSession(projectName, sessionId))
+    expect(messages).toHaveLength(2)
+    expect(messages.map((m) => m.uuid)).toEqual(['user-1', 'assistant-1'])
+  })
+
+  it('should dedupe duplicate uuids keeping the last occurrence', async () => {
+    const sessionId = 'test-session'
+    await writeMessages(sessionId, [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        timestamp: '2025-12-19T01:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'First' }] },
+      },
+      {
+        type: 'user',
+        uuid: 'user-1',
+        timestamp: '2025-12-19T01:00:05.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'Second (latest)' }] },
+      },
+    ])
+
+    const messages = await Effect.runPromise(readSession(projectName, sessionId))
+    expect(messages).toHaveLength(1)
+    expect(messages[0].uuid).toBe('user-1')
+    const payload = messages[0].message as { content: Array<{ text: string }> }
+    expect(payload.content[0].text).toBe('Second (latest)')
+  })
+
+  it('should dedupe 3+ occurrences keeping only the last', async () => {
+    const sessionId = 'test-session'
+    await writeMessages(sessionId, [
+      {
+        type: 'user',
+        uuid: 'dup-uuid',
+        timestamp: '2025-12-19T01:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'v1' }] },
+      },
+      {
+        type: 'user',
+        uuid: 'dup-uuid',
+        timestamp: '2025-12-19T01:00:01.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'v2' }] },
+      },
+      {
+        type: 'user',
+        uuid: 'dup-uuid',
+        timestamp: '2025-12-19T01:00:02.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'v3 (latest)' }] },
+      },
+    ])
+
+    const messages = await Effect.runPromise(readSession(projectName, sessionId))
+    expect(messages).toHaveLength(1)
+    const payload = messages[0].message as { content: Array<{ text: string }> }
+    expect(payload.content[0].text).toBe('v3 (latest)')
+  })
+
+  it('should preserve order of non-duplicated messages around dedup target', async () => {
+    const sessionId = 'test-session'
+    await writeMessages(sessionId, [
+      {
+        type: 'user',
+        uuid: 'user-1',
+        timestamp: '2025-12-19T01:00:00.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'A' }] },
+      },
+      {
+        type: 'user',
+        uuid: 'dup',
+        timestamp: '2025-12-19T01:00:01.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'dup-first' }] },
+      },
+      {
+        type: 'assistant',
+        uuid: 'assistant-1',
+        parentUuid: 'dup',
+        timestamp: '2025-12-19T01:00:02.000Z',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'B' }] },
+      },
+      {
+        type: 'user',
+        uuid: 'dup',
+        timestamp: '2025-12-19T01:00:03.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'dup-last' }] },
+      },
+    ])
+
+    const messages = await Effect.runPromise(readSession(projectName, sessionId))
+    expect(messages).toHaveLength(3)
+    expect(messages.map((m) => m.uuid)).toEqual(['user-1', 'assistant-1', 'dup'])
+    const dupMsg = messages.find((m) => m.uuid === 'dup')!
+    const payload = dupMsg.message as { content: Array<{ text: string }> }
+    expect(payload.content[0].text).toBe('dup-last')
+  })
+
+  it('should not dedupe messages without uuid (summary, file-history-snapshot, custom-title)', async () => {
+    const sessionId = 'test-session'
+    await writeMessages(sessionId, [
+      {
+        type: 'summary',
+        summary: 'Summary one',
+        leafUuid: 'leaf-1',
+      },
+      {
+        type: 'summary',
+        summary: 'Summary two',
+        leafUuid: 'leaf-2',
+      },
+      {
+        type: 'file-history-snapshot',
+        messageId: 'fhs-shared',
+        timestamp: '2025-12-19T01:00:00.000Z',
+        snapshot: { trackedFileBackups: {} },
+      },
+      {
+        type: 'file-history-snapshot',
+        messageId: 'fhs-shared',
+        timestamp: '2025-12-19T01:00:01.000Z',
+        snapshot: { trackedFileBackups: {} },
+      },
+      {
+        type: 'custom-title',
+        customTitle: 'A',
+        sessionId,
+      },
+      {
+        type: 'custom-title',
+        customTitle: 'B',
+        sessionId,
+      },
+    ])
+
+    const messages = await Effect.runPromise(readSession(projectName, sessionId))
+    expect(messages).toHaveLength(6)
+  })
+})

--- a/packages/core/src/session/crud.ts
+++ b/packages/core/src/session/crud.ts
@@ -124,11 +124,25 @@ export const listSessions = (projectName: string) =>
     return sortSessionsByDate(sessions.filter((s): s is NonNullable<typeof s> => s !== null))
   })
 
-// Read session messages
+// Deduplicate messages by `uuid`, keeping the last occurrence. Messages without
+// a `uuid` (summary, file-history-snapshot, custom-title, agent-name) pass through
+// unchanged. Resolves Issue #137 Phase 3 — JSONL files with duplicated uuid records
+// (Syncthing conflicts, repeated history appends, cross-session edits) inflate the
+// rendered DOM and token-usage metrics; we keep only the latest record per uuid.
+export const dedupeMessagesByUuid = <T extends { uuid?: string }>(messages: T[]): T[] => {
+  const lastIndexByUuid = new Map<string, number>()
+  messages.forEach((m, i) => {
+    if (m.uuid) lastIndexByUuid.set(m.uuid, i)
+  })
+  return messages.filter((m, i) => !m.uuid || lastIndexByUuid.get(m.uuid) === i)
+}
+
+// Read session messages (deduplicates duplicate uuids — see dedupeMessagesByUuid)
 export const readSession = (projectName: string, sessionId: string) =>
   Effect.gen(function* () {
     const filePath = path.join(getSessionsDir(), projectName, `${sessionId}.jsonl`)
-    return yield* readJsonlFile<Message>(filePath)
+    const messages = yield* readJsonlFile<Message>(filePath)
+    return dedupeMessagesByUuid(messages)
   })
 
 import { deleteMessageWithChainRepair } from './validation.js'

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -9,6 +9,7 @@ export { listProjects } from './projects.js'
 export {
   listSessions,
   readSession,
+  dedupeMessagesByUuid,
   deleteMessage,
   restoreMessage,
   deleteSession,


### PR DESCRIPTION
## Summary

Resolves Issue #137 Phase 3 (Backend Deduplication / Data Integrity).

JSONL session files with duplicated `uuid` records — caused by file synchronization conflicts, repeated history appends, or cross-session edits — were inflating the rendered DOM cost and token-usage metrics. `readSession` now deduplicates messages by `uuid`, keeping only the **last occurrence**. Messages without a `uuid` (summary `leafUuid`, file-history-snapshot `messageId`, custom-title, agent-name) pass through unchanged.

The pure helper `dedupeMessagesByUuid` is exported via `packages/core/src/session/index.ts` so Issue #137 Phase 2 (UI duplicate warning banner) can reuse the same predicate in a downstream PR.

## Changes

- `packages/core/src/session/crud.ts` — new `dedupeMessagesByUuid` pure helper + `readSession` deduplicates before returning
- `packages/core/src/session/index.ts` — export `dedupeMessagesByUuid` for downstream consumers (Phase 2)
- `packages/core/src/__tests__/crud.test.ts` — 5 new tests in a `readSession dedup (Issue #137 Phase 3)` describe block

## Scope

- Phase 1 (UI hotfix — render-time key uniqueness) already shipped in PR #183
- Phase 2 (UI warning banner) intentionally deferred to a follow-up PR — Phase 2 requires either an API change on `/api/session` or a separate integrity endpoint; keeping this PR focused on data-integrity backend dedup keeps the diff small
- Issue #137 remains open after this PR; only the Phase 3 checkbox is checked

## Refs

Refs #137

## Test Plan

- [x] `pnpm -F @claude-sessions/core test` — 492/492 passing locally (33 in `crud.test.ts`, 5 new in the dedup describe block)
- [x] `pnpm -F @claude-sessions/core build` — succeeds (ESM + DTS)
- [x] `pnpm -F @claude-sessions/web build` — succeeds (isomorphic-core check; no SSR/CSR regression)
- [x] CI: full pnpm install + test on hosted runner — verified via gh pr checks 184 (test ubuntu pass 2m41s, test windows pass 4m10s)
- [x] CI: web e2e (playwright) — verified via gh pr checks 184 (e2e pass 1m18s) — no UI surface changed by this PR, but covered by existing specs
- [x] Manual smoke: covered by 5 new core unit tests with constructed dup-uuid fixtures (crud.test.ts:566-743) — exercises the same readSession code path as the web `/api/session` endpoint; web bundle build pass confirms no SSR/CSR regression



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session messages are now automatically deduplicated by unique identifier when loading, retaining only the most recent version of duplicate entries while preserving all non-duplicate messages.

* **Tests**
  * Added comprehensive test suite validating message deduplication behavior in session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
