### PR TITLE
fix(core): resolve custom-title correctly and skip isMeta reminders in fallback

### DIFF
--- a/packages/core/src/__tests__/crud-title-scan.test.ts
+++ b/packages/core/src/__tests__/crud-title-scan.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as os from 'node:os'
+import { Effect } from 'effect'
+
+vi.mock('../paths.js', async () => {
+  const actual = await vi.importActual('../paths.js')
+  return {
+    ...actual,
+    getSessionsDir: vi.fn(),
+  }
+})
+
+import { listSessions } from '../session/crud.js'
+import { getSessionsDir } from '../paths.js'
+
+async function writeSession(
+  projectDir: string,
+  sessionId: string,
+  messages: Record<string, unknown>[]
+) {
+  const content = messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+  await fs.writeFile(path.join(projectDir, `${sessionId}.jsonl`), content)
+}
+
+// Regression tests for issue #189 — session title resolution
+describe('listSessions title resolution (issue #189)', () => {
+  let tempDir: string
+  let projectDir: string
+  const projectName = '-project-title-scan-test'
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-title-scan-'))
+    projectDir = path.join(tempDir, projectName)
+    await fs.mkdir(projectDir, { recursive: true })
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  // Bug 1: backward scan for custom-title breaks on user/assistant before finding
+  // the record when Claude Code appends conversational turns after rename metadata.
+  it('finds customTitle when conversational turns follow the custom-title record', async () => {
+    const sessionId = 'session-bug1'
+    await writeSession(projectDir, sessionId, [
+      {
+        type: 'user',
+        uuid: 'msg-1',
+        timestamp: '2025-01-01T10:00:00.000Z',
+        message: { role: 'user', content: 'First prompt' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'msg-2',
+        parentUuid: 'msg-1',
+        timestamp: '2025-01-01T10:00:01.000Z',
+        message: { role: 'assistant', content: 'Reply' },
+      },
+      { type: 'custom-title', customTitle: 'My-Session-Name', sessionId },
+      { type: 'agent-name', agentName: 'My-Agent', sessionId },
+      {
+        type: 'user',
+        uuid: 'msg-3',
+        parentUuid: 'msg-2',
+        timestamp: '2025-01-01T10:00:02.000Z',
+        message: { role: 'user', content: 'Follow-up prompt' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'msg-4',
+        parentUuid: 'msg-3',
+        timestamp: '2025-01-01T10:00:03.000Z',
+        message: { role: 'assistant', content: 'Follow-up reply' },
+      },
+      // Claude Code sometimes appends a file-history-snapshot at the very end
+      { type: 'file-history-snapshot', messageId: 'msg-4', snapshot: {}, isSnapshotUpdate: false },
+    ])
+
+    const sessions = await Effect.runPromise(listSessions(projectName))
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].customTitle).toBe('My-Session-Name')
+    expect(sessions[0].agentName).toBe('My-Agent')
+  })
+
+  // Bug 2: fallback (first user message) does not skip synthetic isMeta reminders.
+  // Claude Code injects an isMeta system-reminder describing the rename as an
+  // early "user" entry; extractTitle then displays that raw reminder text.
+  it('skips isMeta system-reminder messages when picking fallback title', async () => {
+    const sessionId = 'session-bug2'
+    await writeSession(projectDir, sessionId, [
+      // Synthetic reminder Claude Code injects as an isMeta user message
+      {
+        type: 'user',
+        isMeta: true,
+        uuid: 'meta-1',
+        timestamp: '2025-01-01T09:59:00.000Z',
+        message: {
+          role: 'user',
+          content:
+            '<system-reminder>\nThe user named this session "My-Session-Name". This may indicate the session\'s focus or intent.\n</system-reminder>',
+        },
+      },
+      // Real first user prompt
+      {
+        type: 'user',
+        uuid: 'msg-1',
+        timestamp: '2025-01-01T10:00:00.000Z',
+        message: { role: 'user', content: 'What is the answer to life?' },
+      },
+      {
+        type: 'assistant',
+        uuid: 'msg-2',
+        parentUuid: 'msg-1',
+        timestamp: '2025-01-01T10:00:01.000Z',
+        message: { role: 'assistant', content: 'Forty-two.' },
+      },
+      // No custom-title record → fallback path is exercised
+    ])
+
+    const sessions = await Effect.runPromise(listSessions(projectName))
+
+    expect(sessions).toHaveLength(1)
+    // Falls back to first non-meta user message, not the reminder text
+    expect(sessions[0].title).toBe('What is the answer to life?')
+    // Reminder text must not leak through
+    expect(sessions[0].title ?? '').not.toContain('<system-reminder>')
+    expect(sessions[0].title ?? '').not.toContain('named this session')
+  })
+})

--- a/packages/core/src/__tests__/crud-title-scan.test.ts
+++ b/packages/core/src/__tests__/crud-title-scan.test.ts
@@ -13,6 +13,8 @@ vi.mock('../paths.js', async () => {
 })
 
 import { listSessions } from '../session/crud.js'
+import { listSessionsMeta } from '../session/crud-streaming.js'
+import { loadProjectTreeData } from '../session/tree.js'
 import { getSessionsDir } from '../paths.js'
 
 async function writeSession(
@@ -130,5 +132,94 @@ describe('listSessions title resolution (issue #189)', () => {
     // Reminder text must not leak through
     expect(sessions[0].title ?? '').not.toContain('<system-reminder>')
     expect(sessions[0].title ?? '').not.toContain('named this session')
+  })
+})
+
+// Same regressions via the VSCode sidebar path (loadProjectTreeData) and the
+// streaming path (listSessionsMeta) — both had their own copies of the logic
+describe.each([
+  {
+    pathName: 'loadProjectTreeData (VSCode sidebar)',
+    load: async (projectName: string) => {
+      const result = await Effect.runPromise(loadProjectTreeData(projectName))
+      return result?.sessions ?? []
+    },
+  },
+  {
+    pathName: 'listSessionsMeta (streaming)',
+    load: (projectName: string) => Effect.runPromise(listSessionsMeta(projectName)),
+  },
+])('$pathName title resolution (issue #189)', ({ load }) => {
+  let tempDir: string
+  let projectDir: string
+  const projectName = '-project-title-scan-alt-path'
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-title-scan-alt-'))
+    projectDir = path.join(tempDir, projectName)
+    await fs.mkdir(projectDir, { recursive: true })
+    vi.mocked(getSessionsDir).mockReturnValue(tempDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('finds customTitle when conversational turns follow the custom-title record', async () => {
+    const sessionId = 'session-alt-bug1'
+    await writeSession(projectDir, sessionId, [
+      {
+        type: 'user',
+        uuid: 'msg-1',
+        timestamp: '2025-01-01T10:00:00.000Z',
+        message: { role: 'user', content: 'First prompt' },
+      },
+      { type: 'custom-title', customTitle: 'My-Session-Name', sessionId },
+      { type: 'agent-name', agentName: 'My-Agent', sessionId },
+      {
+        type: 'user',
+        uuid: 'msg-2',
+        parentUuid: 'msg-1',
+        timestamp: '2025-01-01T10:00:02.000Z',
+        message: { role: 'user', content: 'Follow-up prompt' },
+      },
+      { type: 'file-history-snapshot', messageId: 'msg-2', snapshot: {}, isSnapshotUpdate: false },
+    ])
+
+    const sessions = await load(projectName)
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].customTitle).toBe('My-Session-Name')
+    expect(sessions[0].agentName).toBe('My-Agent')
+  })
+
+  it('skips isMeta system-reminder messages when picking fallback title', async () => {
+    const sessionId = 'session-alt-bug2'
+    await writeSession(projectDir, sessionId, [
+      {
+        type: 'user',
+        isMeta: true,
+        uuid: 'meta-1',
+        timestamp: '2025-01-01T09:59:00.000Z',
+        message: {
+          role: 'user',
+          content:
+            '<system-reminder>\nThe user named this session "My-Session-Name". This may indicate the session\'s focus or intent.\n</system-reminder>',
+        },
+      },
+      {
+        type: 'user',
+        uuid: 'msg-1',
+        timestamp: '2025-01-01T10:00:00.000Z',
+        message: { role: 'user', content: 'What is the answer to life?' },
+      },
+    ])
+
+    const sessions = await load(projectName)
+
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0].title).toBe('What is the answer to life?')
+    expect(sessions[0].title ?? '').not.toContain('<system-reminder>')
   })
 })

--- a/packages/core/src/session/crud-streaming.ts
+++ b/packages/core/src/session/crud-streaming.ts
@@ -7,7 +7,7 @@ import { Effect } from 'effect'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { getSessionsDir } from '../paths.js'
-import { extractTitle, FileReadError } from '../utils.js'
+import { extractTitle, isMetaMessage, FileReadError } from '../utils.js'
 import { filterSessionFiles, buildSessionMeta, sortSessionsByDate } from './crud-helpers.js'
 import { createLogger } from '../logger.js'
 import type { Message, SessionMeta } from '../types.js'
@@ -44,20 +44,21 @@ const scanSessionMeta = async (
 
     if (type === 'user' || type === 'assistant') {
       userAssistantCount++
-      // Reset title fields — only titles after the last message count
-      customTitle = undefined
-      agentName = undefined
+      // Do NOT reset customTitle/agentName here — Claude Code appends
+      // conversational turns after the rename metadata, so the latest
+      // custom-title/agent-name record wins regardless of position
       // Extract timestamp with regex (avoid full parse)
       const tsMatch = line.match(/"timestamp"\s*:\s*"([^"]+)"/)
       if (tsMatch) {
         if (!firstTimestamp) firstTimestamp = tsMatch[1]
         lastTimestamp = tsMatch[1]
       }
-      // Full parse only for first user message (need extractTitle)
+      // Full parse only for first user message (need extractTitle).
+      // Skip synthetic isMeta reminders (rename announcements)
       if (type === 'user' && title === undefined) {
         try {
           const msg = JSON.parse(line) as Message
-          title = extractTitle(msg.message)
+          if (!isMetaMessage(msg)) title = extractTitle(msg.message)
         } catch {
           /* skip malformed */
         }

--- a/packages/core/src/session/crud.ts
+++ b/packages/core/src/session/crud.ts
@@ -10,6 +10,7 @@ import {
   extractTitle,
   fileExists,
   isContinuationSummary,
+  isMetaMessage,
   cleanupSplitFirstMessage,
   parseJsonlLines,
   readJsonlFile,
@@ -41,9 +42,7 @@ export const updateSessionSummary = (projectName: string, sessionId: string, new
       // Add new summary at the beginning. Anchor leafUuid on the first real
       // user prompt — synthetic isMeta reminders (rename announcements) have
       // no meaningful uuid to reference.
-      const firstUserMsg = messages.find(
-        (m) => m.type === 'user' && !(m as { isMeta?: boolean }).isMeta
-      )
+      const firstUserMsg = messages.find((m) => m.type === 'user' && !isMetaMessage(m))
       const summaryMsg = {
         type: 'summary',
         summary: newSummary,
@@ -80,7 +79,7 @@ const readSessionMeta = (projectPath: string, file: string, projectName: string)
     // Code injects when a session is renamed — those are not user prompts.
     const title = pipe(
       messages,
-      A.findFirst((m) => m.type === 'user' && !(m as { isMeta?: boolean }).isMeta),
+      A.findFirst((m) => m.type === 'user' && !isMetaMessage(m)),
       O.map((m) => extractTitle(m.message)),
       O.getOrUndefined
     )

--- a/packages/core/src/session/crud.ts
+++ b/packages/core/src/session/crud.ts
@@ -38,8 +38,12 @@ export const updateSessionSummary = (projectName: string, sessionId: string, new
       // Update existing summary
       messages[summaryIdx] = { ...messages[summaryIdx], summary: newSummary }
     } else {
-      // Add new summary at the beginning
-      const firstUserMsg = messages.find((m) => m.type === 'user')
+      // Add new summary at the beginning. Anchor leafUuid on the first real
+      // user prompt — synthetic isMeta reminders (rename announcements) have
+      // no meaningful uuid to reference.
+      const firstUserMsg = messages.find(
+        (m) => m.type === 'user' && !(m as { isMeta?: boolean }).isMeta
+      )
       const summaryMsg = {
         type: 'summary',
         summary: newSummary,
@@ -71,19 +75,25 @@ const readSessionMeta = (projectPath: string, file: string, projectName: string)
     )
     const hasSummary = messages.some((m) => m.type === 'summary')
 
+    // Fallback title = first real user prompt. Skip synthetic isMeta reminders
+    // (e.g., '<system-reminder>The user named this session "X"...') that Claude
+    // Code injects when a session is renamed — those are not user prompts.
     const title = pipe(
       messages,
-      A.findFirst((m) => m.type === 'user'),
+      A.findFirst((m) => m.type === 'user' && !(m as { isMeta?: boolean }).isMeta),
       O.map((m) => extractTitle(m.message)),
       O.getOrUndefined
     )
 
-    // Only titles after the last user/assistant message count as current
+    // Scan backward for the latest custom-title / agent-name records. Keep
+    // scanning past conversational turns — Claude Code appends user/assistant
+    // messages (and file-history-snapshot) after the rename metadata, so
+    // stopping at the first user/assistant would miss the record entirely.
     let customTitle: string | undefined
     let agentName: string | undefined
     for (let i = messages.length - 1; i >= 0; i--) {
+      if (customTitle !== undefined && agentName !== undefined) break
       const m = messages[i]
-      if (m.type === 'user' || m.type === 'assistant') break
       if (customTitle === undefined && m.type === 'custom-title') {
         customTitle = (m as { customTitle?: string }).customTitle ?? undefined
       } else if (agentName === undefined && m.type === 'agent-name') {

--- a/packages/core/src/session/tree.ts
+++ b/packages/core/src/session/tree.ts
@@ -11,6 +11,7 @@ import {
   getDisplaySortTimestamp,
   getSummarySortTimestamp,
   isErrorSessionTitle,
+  isMetaMessage,
   parseJsonlLines,
   fileExists,
   tryParseJsonLine,
@@ -179,15 +180,22 @@ const loadSessionTreeDataInternal = (
       }
     }
 
-    // Get first user message
-    const firstUserMsg = messages.find((m) => m.type === 'user') as Message | undefined
+    // Get first real user message — skip synthetic isMeta reminders
+    // (e.g., the rename announcement Claude Code injects) so they never
+    // become the fallback title
+    const firstUserMsg = messages.find((m) => m.type === 'user' && !isMetaMessage(m)) as
+      | Message
+      | undefined
 
-    // Scan from end: only titles after the last user/assistant message count
+    // Scan backward for the latest custom-title / agent-name records. Keep
+    // scanning past conversational turns — Claude Code appends user/assistant
+    // messages (and file-history-snapshot) after the rename metadata, so
+    // stopping at the first user/assistant would miss the record entirely.
     let customTitle: string | undefined
     let agentName: string | undefined
     for (let i = messages.length - 1; i >= 0; i--) {
+      if (customTitle !== undefined && agentName !== undefined) break
       const msg = messages[i]
-      if (msg.type === 'user' || msg.type === 'assistant') break
       if (customTitle === undefined && msg.type === 'custom-title') {
         customTitle = (msg as { type: 'custom-title'; customTitle?: string }).customTitle
       } else if (agentName === undefined && msg.type === 'agent-name') {

--- a/packages/core/src/session/tree.ts
+++ b/packages/core/src/session/tree.ts
@@ -234,7 +234,7 @@ const loadSessionTreeDataInternal = (
           )
 
           let agentName: string | undefined
-          const firstAgentMsg = agentMsgs.find((m) => m.type === 'user')
+          const firstAgentMsg = agentMsgs.find((m) => m.type === 'user' && !isMetaMessage(m))
           if (firstAgentMsg) {
             const text = extractTextContent(firstAgentMsg.message as Message['message'])
             if (text) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -130,6 +130,8 @@ export interface Message extends TypedObject {
   summary?: string
   /** Flag indicating this is a context continuation summary */
   isCompactSummary?: boolean
+  /** Flag indicating a synthetic meta message (e.g., rename announcement reminder) */
+  isMeta?: boolean
   /** Tool use result (string for rejections, AskUserQuestionResult for Q&A) */
   toolUseResult?: ToolUseResult
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -144,6 +144,11 @@ export const isErrorSessionTitle = (title: string | undefined): boolean => {
   return ERROR_SESSION_PATTERNS.some((pattern) => title.includes(pattern))
 }
 
+// Check if a message is a synthetic meta entry (e.g., the system-reminder
+// Claude Code injects to announce a session rename) rather than a real prompt.
+// Accepts both Message and JsonlRecord shapes — the cast is confined here
+export const isMetaMessage = (msg: object): boolean => (msg as { isMeta?: unknown }).isMeta === true
+
 // Check if a message is a continuation summary (from compact)
 export const isContinuationSummary = (msg: Message): boolean => {
   // isCompactSummary flag is set by Claude Code for continuation summaries


### PR DESCRIPTION
## Summary

Two independent bugs in `packages/core/src/session/crud.ts` combined to occasionally display the raw `<system-reminder>The user named this session "X"...</system-reminder>` text as the session title after a rename.

- **Bug 1** — Backward scan in `readSessionMeta` broke on the first `user`/`assistant` message. Claude Code appends conversational turns (and a trailing `file-history-snapshot`) after `custom-title` metadata, so the loop exited before ever seeing the record → `customTitle` stayed `undefined` → fallback path.
- **Bug 2** — Fallback title (first `user` message) did not skip `isMeta: true` synthetic reminders. The rename announcement Claude Code injects as an early `isMeta` user entry then became the visible title. The same pattern applied to `updateSessionSummary`'s `leafUuid` anchor.

Fix:
- Keep scanning backward until **both** `customTitle` and `agentName` are resolved (drop the early `break`).
- Filter `!m.isMeta` in both first-user lookups.

Closes #189

Reporter: @a5180352 — the analysis in the issue matched the source exactly; both bugs were reproducible with the fixtures they described.

## Test Plan

- [x] Add regression test: `custom-title` followed by `user`/`assistant` + `file-history-snapshot` → `customTitle` resolved to `My-Session-Name` (bug 1)
- [x] Add regression test: `isMeta` reminder as first user message + no `custom-title` → fallback title = first real prompt, reminder text absent (bug 2)
- [x] `pnpm -F @claude-sessions/core test` → 494/494 passing (28 files)
- [x] `pnpm -F @claude-sessions/core build` → clean
- [x] CodeRabbit walkthrough (arrived 2026-07-02, Pro full review)
- [x] Copilot review (arrived 2026-07-02, 2 inline comments)
- [x] Review follow-up (commit 2c2cc1f): same two-bug fix applied to `tree.ts` (VSCode sidebar path) + `crud-streaming.ts` (streaming path) via shared `isMetaMessage()` helper
- [x] Regression tests extended to `loadProjectTreeData` + `listSessionsMeta` (describe.each, 6 tests total) — 498/498 passing
- [x] CI green on 633af85 (all 3 commits: 6bf0930, 2c2cc1f, 633af85) — e2e + test ubuntu/windows + CodeRabbit
- [x] CodeRabbit re-review nitpick (sub-agent name isMeta filter) resolved in 633af85 — zero open findings

## Notes on release impact

`fix(core)` matches both `.releaserc.json` (vscode line) and `.releaserc-npm.json` (npm catch-all) → patch bump on both lines when this lands on main. No manual version work required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session title selection so temporary system reminders and other synthetic entries no longer appear in session titles.
  * Fixed session metadata handling so custom session titles and agent names are correctly detected even when they are added later in the conversation.
  * Session summaries now anchor to the first real user message, avoiding metadata-only messages from affecting the result.
  * Added regression coverage for these session listing and title-resolution cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



