### PR TITLE
fix(ci): correct semantic-release config so main actually releases

### DIFF
--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -55,4 +55,11 @@ jobs:
       - name: Run semantic-release (npm config)
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_PAT }}
-        run: npx semantic-release --extends ./.releaserc-npm.json
+        # semantic-release auto-discovers .releaserc.json (the vscode config) as the base and merges
+        # `--extends` UNDER it, so `--extends ./.releaserc-npm.json` was fully shadowed (base kept the
+        # vscode tagFormat + plugins → npm never released). Overwrite the auto-discovered config with
+        # the npm config for this job so it becomes the effective base. Not committed: the git plugin
+        # only stages the configured assets, so this working-tree change is discarded with the runner.
+        run: |
+          cp .releaserc-npm.json .releaserc.json
+          npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,14 +6,14 @@
       {
         "preset": "angular",
         "releaseRules": [
+          { "release": false },
           { "type": "feat", "scope": "vscode", "release": "minor" },
           { "type": "fix", "scope": "vscode", "release": "patch" },
           { "type": "perf", "scope": "vscode", "release": "patch" },
           { "type": "feat", "scope": "core", "release": "minor" },
           { "type": "fix", "scope": "core", "release": "patch" },
           { "type": "perf", "scope": "core", "release": "patch" },
-          { "breaking": true, "release": "minor" },
-          { "release": false }
+          { "breaking": true, "release": "minor" }
         ]
       }
     ],


### PR DESCRIPTION
## Summary

Two compounding config bugs left every `main` release stranded — no npm package and no VS Code extension has shipped from `main` since `v0.5.0` / `vscode-v0.4.9`, even though `fix(core)` and `fix(web)` commits have landed.

### Bug 1 — trailing `{ "release": false }` catch-all poisons every rule (`.releaserc.json`)

`@semantic-release/commit-analyzer` keeps the **highest** release type across **all** matching `releaseRules` for a commit. `false` has array index `-1`, which outranks every real release type, so a trailing `{ "release": false }` catch-all (matching every commit) forced every positive rule down to `false`. The vscode line released **nothing** — not even `fix(vscode)` / `feat(vscode)`.

**Fix:** move the catch-all to the **front**. A `false` current type is falsy, so `compareReleaseTypes` (`!currentReleaseType`) lets a later positive rule override it, while commits matching *only* the catch-all still resolve to no release.

### Bug 2 — npm job loads the wrong config (`npm-semantic-release.yml`)

The job ran `semantic-release --extends ./.releaserc-npm.json`, but semantic-release auto-discovers `.releaserc.json` (the vscode config) as the base and merges `--extends` **under** it. The npm config was fully shadowed → wrong `tagFormat` (`vscode-v`) + vscode plugins → npm never released.

**Fix:** overwrite the auto-discovered `.releaserc.json` with the npm config inside the npm job before running. Filenames are unchanged; the overwrite is a throwaway working-tree change since the git plugin only stages configured assets.

## Verification

Driven through the real `@semantic-release/commit-analyzer` (v13.0.1) against the actual `main` commit history since the stable baselines:

| Rule set | `fix(core)` | `fix(vscode)` | `fix(web)` | Aggregate over real main commits |
|----------|-------------|---------------|------------|----------------------------------|
| vscode `.releaserc.json` **before** | NO RELEASE | NO RELEASE | NO RELEASE | **NO RELEASE** (stuck at vscode-v0.4.9) |
| vscode `.releaserc.json` **after** | patch | patch | NO RELEASE | **patch → vscode-v0.4.10** |
| npm `.releaserc-npm.json` (now loaded) | patch | patch | patch | **patch → v0.5.1** |

After merge, `main` releases **npm v0.5.1** + **vscode-v0.4.10**.

## Follow-up (out of scope here)

The npm config's `(vscode)`-scope `release: false` rules do **not** actually block vscode-scoped commits — the later catch-all `release: patch` rules override them (same non-sticky-`false` semantics), so `fix(vscode)` resolves to `patch` on the npm line. That is *over*-release (harmless while no vscode-only commit is pending), not the under-release this PR fixes, and correcting it needs scope-negation rules that also preserve scopeless commits. To be tracked separately.

## Test Plan

- [x] [post-merge] Merge to `main` → `main-semantic-release.yml` (production-vscode approval) tags `vscode-v0.4.10`; `release-vscode.yml` publishes — verified 2026-07-04: run 28690198779 tagged vscode-v0.4.10 ✅ (config fix works); release-vscode run 28690574665 built VSIX + created the GitHub Release, but the Marketplace publish step failed with "es6kr.claude-sessions v0.4.10 already exists" — 0.4.10 was pre-burned on Marketplace/Open VSX by an earlier out-of-band publish. Registry artifacts ship as 0.4.11 on the next release-triggering commit
- [x] [post-merge] Merge to `main` → `npm-semantic-release.yml` (production-npm approval) tags `v0.5.1`; `publish-npm.yml` publishes `@claude-sessions/{core,ui,web}` + `claude-sessions-mcp` — verified 2026-07-04: run 28690665076 (re-dispatch after checkout race with the vscode release commit) tagged v0.5.1 ✅; publish-npm run 28690689488 success; npm dist-tags latest=0.5.1 confirmed for all 4 packages
- [x] Analyzer behavior verified in isolation against the real main commit history (see Verification table)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation so package releases use the intended configuration consistently.
  * Updated release rule ordering to make versioning behavior more predictable for future changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

