### PR TITLE
fix(ci): veto vscode-scoped commits on the npm release line

### DIFF
--- a/.releaserc-npm.json
+++ b/.releaserc-npm.json
@@ -6,14 +6,6 @@
       {
         "preset": "angular",
         "releaseRules": [
-          { "type": "feat", "scope": "vscode", "release": false },
-          { "type": "fix", "scope": "vscode", "release": false },
-          { "type": "perf", "scope": "vscode", "release": false },
-          { "type": "chore", "scope": "vscode", "release": false },
-          { "type": "refactor", "scope": "vscode", "release": false },
-          { "type": "docs", "scope": "vscode", "release": false },
-          { "type": "test", "scope": "vscode", "release": false },
-          { "type": "ci", "scope": "vscode", "release": false },
           { "type": "feat", "release": "patch" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },
@@ -22,7 +14,15 @@
           { "type": "docs", "release": "patch" },
           { "type": "test", "release": "patch" },
           { "type": "ci", "release": "patch" },
-          { "breaking": true, "release": "minor" }
+          { "breaking": true, "release": "minor" },
+          { "type": "feat", "scope": "vscode", "release": false },
+          { "type": "fix", "scope": "vscode", "release": false },
+          { "type": "perf", "scope": "vscode", "release": false },
+          { "type": "chore", "scope": "vscode", "release": false },
+          { "type": "refactor", "scope": "vscode", "release": false },
+          { "type": "docs", "scope": "vscode", "release": false },
+          { "type": "test", "scope": "vscode", "release": false },
+          { "type": "ci", "scope": "vscode", "release": false }
         ]
       }
     ],


### PR DESCRIPTION
## Summary

Follow-up to PR #192 (disclosed there as the remaining "Follow-up" item): the npm release line could **over-release** on vscode-scoped commits.

`.releaserc-npm.json` listed the eight vscode-scope `{release: false}` rules **before** the unscoped typed rules. `@semantic-release/commit-analyzer` treats `release: false` as non-sticky — any later matching rule overrides a falsy current release type — so a `fix(vscode)` commit fell through to `{type: fix, release: patch}` and bumped the npm packages; a breaking vscode commit even computed `minor`.

This PR moves the vscode veto rules to the **end** of `releaseRules` (after the typed rules and the `breaking` rule), making them the last match so they always win for vscode-scoped commits. Pure reorder — no rule added or removed.

## Repro evidence

Verified with `@semantic-release/commit-analyzer` v13 `analyzeCommits()` on both rule orders:

| Commit | old (main) | new (this PR) |
|--------|-----------|---------------|
| `fix(vscode): x` | patch ← over-release | **null** |
| `fix(core): x` | patch | patch |
| `chore(deps): x` | patch | patch |
| `fix(vscode)` + `BREAKING CHANGE` | minor ← over-release | **null** |
| `fix(core)` + `BREAKING CHANGE` | minor | minor |

## Test Plan

- [x] commit-analyzer v13 repro: vscode-scoped commits (incl. breaking) compute no release on the new order; core/deps behavior unchanged (table above)
- [x] Pure reorder verified: `git diff` shows only the 8 vscode rows moved, no content change
- [ ] [post-merge] Next vscode-only commit batch on main produces no npm-line release (npm-semantic-release run computes "no release") — tracking: registered in maintainer follow-up checklist (verify on the next vscode-scoped commit batch)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation rules to better classify future changes for versioning.
  * Preserved the existing no-release handling for editor-specific changes while ensuring other common change types can trigger appropriate patch or minor releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
