### PR TITLE
ci: add beta prerelease channel to npm release config [skip release]

### DIFF
--- a/.releaserc-npm.json
+++ b/.releaserc-npm.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["main", { "name": "beta", "prerelease": true }],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Summary
- Make `main`'s `.releaserc-npm.json` `branches` config symmetric with the `beta` branch: `["main"]` → `["main", { "name": "beta", "prerelease": true }]`.
- semantic-release recommends an identical `branches` config across all release branches; `main` was the only branch not declaring the `beta` prerelease channel.

## Changes
| File | Change |
|------|--------|
| `.releaserc-npm.json` | `branches` adds the `beta` prerelease channel entry |

## Context
Hygiene only. This does **not** by itself stop `main` from finalizing/advancing a version while the `beta` channel is mid-lifecycle on that base — that is prevented by the pre-approval check on the `production-npm` environment (`npm view @claude-sessions/core dist-tags` before approving). Symmetric config just makes `main`'s semantic-release aware of the `beta` channel.

`[skip release]` is in the title so a squash-merge does not trigger an npm release from this config-only change.

## Test plan
- [x] **[general]** `npx semantic-release --dry-run` on `main` with the added `beta` channel: config parses, `main`'s next release unchanged ("no relevant changes" at the current release-commit HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for a beta prerelease release channel alongside the main release line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->