### PR TITLE
ci: add shared concurrency group to main-semantic-release workflow

### DIFF
--- a/.github/workflows/main-semantic-release.yml
+++ b/.github/workflows/main-semantic-release.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Two semantic-release runs sharing main HEAD must not race on git push.
+# Same group as npm-semantic-release.yml so the vscode and npm lines queue sequentially.
+concurrency:
+  group: semantic-release-main
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write


### PR DESCRIPTION
## What

Add the shared `concurrency` group (`semantic-release-main`, `cancel-in-progress: false`) to `main-semantic-release.yml` — the same group `npm-semantic-release.yml` already declares.

## Why

The npm workflow's comment says "Two semantic-release runs sharing main HEAD must not race on git push", but only the npm workflow declares the group. GitHub Actions serializes runs across workflows only when both declare the same group — with the block missing on the vscode line, a single `main` push starts both semantic-release jobs in parallel, and both can push a release commit/tag back to `main` (the race was previously mitigated only by a documented sequential-approval procedure).

## Test Plan

- [x] CI green on this PR — all checks SUCCESS at head 5da880f (test ubuntu/windows, e2e, CodeRabbit; re-verified at merge 2026-07-16)
- [x] After merge, on the next `main` push: the `main semantic-release` and `npm semantic-release` runs queue sequentially on the shared concurrency group instead of running in parallel (visible on the Actions run page) — verified 2026-07-16 on merge push 9557414: `main semantic-release` run 29472850646 held the group (waiting at env gate), `npm semantic-release` run 29472850633 concluded `skipped` via concurrency dedup — no parallel race. Note: the losing line's same-push run is skipped (not queued); on a release-bearing push that line processes on the next push

Relates to #128.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow coordination to prevent overlapping release runs and reduce the risk of conflicting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
