### PR TITLE
fix(vscode): resolve deferred review findings from the 3-way resume picker

### DIFF
--- a/packages/vscode-extension/README.md
+++ b/packages/vscode-extension/README.md
@@ -16,7 +16,7 @@ View messages with tab interface. Inspect user/assistant turns, tool calls, and 
 
 - **Session Browser**: View all Claude Code projects and sessions in a tree view
 - **Web UI Integration**: View messages, delete messages, split sessions
-- **Resume Session**: Continue any session directly in terminal
+- **Resume Session**: Continue any session in a terminal or inside the official Claude Code extension
 - **Session Management**: Rename, delete, and move sessions between projects
 - **Cleanup**: Remove empty and invalid sessions in bulk
 - **Drag & Drop**: Move sessions between projects
@@ -50,12 +50,23 @@ Search for "Claude Code Sessions" in VS Code Extensions.
 
 ## Commands
 
-| Command                                | Description                           |
-| -------------------------------------- | ------------------------------------- |
-| `Claude Code Sessions: Refresh`        | Refresh the session tree              |
-| `Claude Code Sessions: Open Web UI`    | Open the web interface                |
-| `Claude Code Sessions: Cleanup`        | Remove empty/invalid sessions         |
-| `Claude Code Sessions: Resume Session` | Resume session in integrated terminal |
+| Command                                | Description                                        |
+| -------------------------------------- | -------------------------------------------------- |
+| `Claude Code Sessions: Refresh`        | Refresh the session tree                           |
+| `Claude Code Sessions: Open Web UI`    | Open the web interface                             |
+| `Claude Code Sessions: Cleanup`        | Remove empty/invalid sessions                      |
+| `Claude Code Sessions: Resume Session` | Resume session (terminal or Claude Code extension) |
+
+## Resume modes (`claudeSessions.defaultTerminalMode`)
+
+Resume Session supports three destinations, controlled by the `claudeSessions.defaultTerminalMode` setting:
+
+- **`ask`** (default) — shows a picker on every resume. When the session belongs to the current workspace, the picker offers all three destinations (Internal Terminal / External Terminal / Claude Code Extension); for a session from another workspace, the Claude Code Extension entry is hidden because the official extension can only resolve sessions of the open workspace.
+- **`internal`** — skips the picker and always resumes in the VSCode integrated terminal.
+- **`external`** — skips the picker and always resumes in the system default terminal.
+- **`anthropic`** — skips the picker and opens the session inside the official Claude Code extension (installs it on demand). If the session belongs to a different workspace, a fallback picker with the two terminal options appears instead.
+
+`Open Terminal Here` and `Start Claude in Folder` are terminal launchers, so they intentionally offer only the two terminal destinations regardless of this setting.
 
 ## Requirements
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -695,7 +695,15 @@ export function activate(context: vscode.ExtensionContext) {
         // `do script` / `cmd /k` string interpolation (external), and the
         // anthropic URI query parameter. Validate once, up front, so no
         // branch can act on an unvalidated session ID.
-        if (!/^[A-Za-z0-9_-]+$/.test(item.sessionId)) {
+        //
+        // typeof-gated (not just regex.test): this command is registered
+        // globally, so any extension can invoke it via
+        // vscode.commands.executeCommand('claudeSessions.resumeSession', ...)
+        // with an arbitrary payload, bypassing SessionTreeItem's compile-time
+        // `sessionId: string`. RegExp#test coerces its argument via ToString,
+        // so a bare regex check on undefined/null would pass (they stringify
+        // to "undefined"/"null", both of which match [A-Za-z0-9_-]+).
+        if (typeof item.sessionId !== 'string' || !/^[A-Za-z0-9_-]+$/.test(item.sessionId)) {
           void vscode.window.showErrorMessage('Invalid session id; cannot resume session.')
           return
         }

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -686,7 +686,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       'claudeSessions.resumeSession',
       async (item: SessionTreeItem) => {
-        if (item.type !== 'session') return
+        if (!item || item.type !== 'session') return
 
         // Session IDs are attacker-controllable in a shared repository (a
         // session file can be crafted or renamed) and flow unescaped into

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -6,7 +6,7 @@ import { Effect } from 'effect'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { outputChannel } from './output'
 import { SESSION_EDITOR_VIEW_TYPE, SessionEditorProvider } from './sessionEditorProvider'
-import { decideResume, type ResumeMode } from './lib/crossWorkspace'
+import { decideResume, ensureClaudeCodeExtension, type ResumeMode } from './lib/crossWorkspace'
 
 let webServerProcess: ChildProcess | null = null
 
@@ -814,46 +814,22 @@ export function activate(context: vscode.ExtensionContext) {
           // sessionId is already validated at the top of this handler.
           const sessionId = item.sessionId
 
-          let claudeExt = vscode.extensions.getExtension('anthropic.claude-code')
-          if (!claudeExt) {
-            const installChoice = await vscode.window.showWarningMessage(
-              'The official Claude Code extension is not installed.',
-              'Install',
-              'Cancel'
-            )
-            if (installChoice !== 'Install') return
-            await vscode.commands.executeCommand(
-              'workbench.extensions.installExtension',
-              'anthropic.claude-code'
-            )
-            // Auto-continue: pick up the freshly installed extension and fall
-            // through to the activation + URI dispatch below, so the user's
-            // original resume intent completes without re-running the command.
-            claudeExt = vscode.extensions.getExtension('anthropic.claude-code')
-            if (!claudeExt) {
-              // The extension host has not surfaced the new install yet — the
-              // one remaining case where a manual re-trigger is required.
-              void vscode.window.showInformationMessage(
-                'Claude Code extension installed — run Resume Session again to open the session.'
-              )
-              return
-            }
-          }
-
-          // Defensive activation: getExtension returns the Extension object even
-          // when it is installed-but-disabled (isActive === false). Without this
-          // step the URI dispatch below silently fails because no UriHandler is
-          // registered until activation. (PR #172 Internal Code Review #2.)
-          if (!claudeExt.isActive) {
-            try {
-              await claudeExt.activate()
-            } catch (err) {
-              void vscode.window.showErrorMessage(
-                `Failed to activate Claude Code extension: ${err instanceof Error ? err.message : String(err)}`
-              )
-              return
-            }
-          }
+          // Install-on-demand + defensive activation (installed-but-disabled
+          // extensions still surface via getExtension with isActive===false;
+          // without activation the URI dispatch below silently fails because
+          // no UriHandler is registered yet — PR #172 Internal Code Review #2).
+          // Extracted to ensureClaudeCodeExtension so it's unit-testable
+          // without a live open workspace folder (see crossWorkspace.ts).
+          const ensureResult = await ensureClaudeCodeExtension({
+            getExtension: (id) => vscode.extensions.getExtension(id),
+            showWarningMessage: (message, ...items) =>
+              vscode.window.showWarningMessage(message, ...items),
+            installExtension: (id) =>
+              vscode.commands.executeCommand('workbench.extensions.installExtension', id),
+            showInformationMessage: (message) => void vscode.window.showInformationMessage(message),
+            showErrorMessage: (message) => void vscode.window.showErrorMessage(message),
+          })
+          if (ensureResult.kind !== 'ready') return
 
           // Cross-workspace dispatch is unreachable here: `decideResume`
           // above converts cross-workspace + anthropic intent into a

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -688,6 +688,18 @@ export function activate(context: vscode.ExtensionContext) {
       async (item: SessionTreeItem) => {
         if (item.type !== 'session') return
 
+        // Session IDs are attacker-controllable in a shared repository (a
+        // session file can be crafted or renamed) and flow unescaped into
+        // shell commands in every dispatch branch below: terminal.sendText
+        // (internal), resumeSession -> startClaude's `bash -c` / AppleScript
+        // `do script` / `cmd /k` string interpolation (external), and the
+        // anthropic URI query parameter. Validate once, up front, so no
+        // branch can act on an unvalidated session ID.
+        if (!/^[A-Za-z0-9_-]+$/.test(item.sessionId)) {
+          void vscode.window.showErrorMessage('Invalid session id; cannot resume session.')
+          return
+        }
+
         const { defaultTerminalMode, cliFlags } = getConfig()
         const cliCommand = cliFlags
           ? `claude --resume ${item.sessionId} ${cliFlags}`
@@ -791,15 +803,8 @@ export function activate(context: vscode.ExtensionContext) {
           // antigravity / vscodium / ...) so the dispatch stays in-process
           // on every Open VSX-supported fork.
           // Addresses discussion #159 (option M2 — 3-way integrated picker).
-          // SessionTreeItem guarantees sessionId: string for type === 'session'
-          // (guarded at the top of this handler); the regex below is the URI
-          // injection guard, so no defensive String() coercion is needed —
-          // matching the raw usage in the internal/external branches.
+          // sessionId is already validated at the top of this handler.
           const sessionId = item.sessionId
-          if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
-            void vscode.window.showErrorMessage('Invalid session id; cannot resume session.')
-            return
-          }
 
           let claudeExt = vscode.extensions.getExtension('anthropic.claude-code')
           if (!claudeExt) {

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -791,26 +791,40 @@ export function activate(context: vscode.ExtensionContext) {
           // antigravity / vscodium / ...) so the dispatch stays in-process
           // on every Open VSX-supported fork.
           // Addresses discussion #159 (option M2 — 3-way integrated picker).
-          const sessionId = String(item.sessionId ?? '')
+          // SessionTreeItem guarantees sessionId: string for type === 'session'
+          // (guarded at the top of this handler); the regex below is the URI
+          // injection guard, so no defensive String() coercion is needed —
+          // matching the raw usage in the internal/external branches.
+          const sessionId = item.sessionId
           if (!/^[A-Za-z0-9_-]+$/.test(sessionId)) {
             void vscode.window.showErrorMessage('Invalid session id; cannot resume session.')
             return
           }
 
-          const claudeExt = vscode.extensions.getExtension('anthropic.claude-code')
+          let claudeExt = vscode.extensions.getExtension('anthropic.claude-code')
           if (!claudeExt) {
             const installChoice = await vscode.window.showWarningMessage(
-              'Claude Code extension (anthropic.claude-code) is not installed.',
+              'The official Claude Code extension is not installed.',
               'Install',
               'Cancel'
             )
-            if (installChoice === 'Install') {
-              await vscode.commands.executeCommand(
-                'workbench.extensions.installExtension',
-                'anthropic.claude-code'
+            if (installChoice !== 'Install') return
+            await vscode.commands.executeCommand(
+              'workbench.extensions.installExtension',
+              'anthropic.claude-code'
+            )
+            // Auto-continue: pick up the freshly installed extension and fall
+            // through to the activation + URI dispatch below, so the user's
+            // original resume intent completes without re-running the command.
+            claudeExt = vscode.extensions.getExtension('anthropic.claude-code')
+            if (!claudeExt) {
+              // The extension host has not surfaced the new install yet — the
+              // one remaining case where a manual re-trigger is required.
+              void vscode.window.showInformationMessage(
+                'Claude Code extension installed — run Resume Session again to open the session.'
               )
+              return
             }
-            return
           }
 
           // Defensive activation: getExtension returns the Extension object even
@@ -902,6 +916,11 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }),
 
+    // openTerminalHere and startClaudeInFolder deliberately keep the 2-way
+    // Internal/External picker instead of resumeSession's 3-way: both are
+    // terminal launchers (no session to resume), and the Claude Code Extension
+    // option is a webview, not a terminal flavor. A `defaultTerminalMode` of
+    // 'anthropic' (or 'ask') therefore falls through to the 2-way picker here.
     vscode.commands.registerCommand(
       'claudeSessions.openTerminalHere',
       async (item: SessionTreeItem) => {

--- a/packages/vscode-extension/src/lib/crossWorkspace.ts
+++ b/packages/vscode-extension/src/lib/crossWorkspace.ts
@@ -135,3 +135,77 @@ export function decideResume(input: {
   // defaultMode === 'ask' — picker with 2 or 3 options
   return { kind: 'picker', options: pickerOptions(cross) }
 }
+
+export interface ClaudeExtensionLike {
+  readonly isActive: boolean
+  activate(): PromiseLike<unknown>
+}
+
+export interface EnsureClaudeCodeExtensionDeps {
+  getExtension: (id: string) => ClaudeExtensionLike | undefined
+  showWarningMessage: (message: string, ...items: string[]) => PromiseLike<string | undefined>
+  installExtension: (id: string) => PromiseLike<unknown>
+  showInformationMessage: (message: string) => void
+  showErrorMessage: (message: string) => void
+}
+
+export type EnsureClaudeCodeExtensionResult =
+  | { kind: 'ready'; extension: ClaudeExtensionLike }
+  | { kind: 'declined' }
+  | { kind: 'install-pending' }
+  | { kind: 'activation-failed'; error: string }
+
+const ANTHROPIC_EXTENSION_ID = 'anthropic.claude-code'
+
+/**
+ * Ensure the official Claude Code extension is installed and active,
+ * prompting to install it on demand.
+ *
+ * Extracted from resumeSession's anthropic branch so it can be unit-tested
+ * with mock deps instead of requiring a live open workspace folder in the
+ * test-electron host — the anthropic branch is otherwise unreachable there,
+ * since `decideResume` always routes cross-workspace when no folder is open.
+ * Deps are typed structurally (PromiseLike, not vscode.Thenable) to keep this
+ * file free of vscode imports, matching the rest of the module.
+ */
+export async function ensureClaudeCodeExtension(
+  deps: EnsureClaudeCodeExtensionDeps
+): Promise<EnsureClaudeCodeExtensionResult> {
+  let ext = deps.getExtension(ANTHROPIC_EXTENSION_ID)
+
+  if (!ext) {
+    const choice = await deps.showWarningMessage(
+      'The official Claude Code extension is not installed.',
+      'Install',
+      'Cancel'
+    )
+    if (choice !== 'Install') return { kind: 'declined' }
+
+    await deps.installExtension(ANTHROPIC_EXTENSION_ID)
+
+    // Auto-continue: pick up the freshly installed extension and fall through
+    // to activation, so the original resume intent completes without a
+    // second manual trigger.
+    ext = deps.getExtension(ANTHROPIC_EXTENSION_ID)
+    if (!ext) {
+      // The extension host has not surfaced the new install yet — the one
+      // remaining case where a manual re-trigger is required.
+      deps.showInformationMessage(
+        'Claude Code extension installed — run Resume Session again to open the session.'
+      )
+      return { kind: 'install-pending' }
+    }
+  }
+
+  if (!ext.isActive) {
+    try {
+      await ext.activate()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      deps.showErrorMessage(`Failed to activate Claude Code extension: ${message}`)
+      return { kind: 'activation-failed', error: message }
+    }
+  }
+
+  return { kind: 'ready', extension: ext }
+}

--- a/packages/vscode-extension/src/lib/crossWorkspace.ts
+++ b/packages/vscode-extension/src/lib/crossWorkspace.ts
@@ -29,8 +29,21 @@ export type ResumeDecision =
   | { kind: 'picker'; options: ReadonlyArray<ResumeMode> }
   | { kind: 'fallback-picker'; options: ReadonlyArray<ResumeMode>; reason: 'cross-workspace' }
 
+/**
+ * Canonicalize a path for equality comparison only (both sides of every
+ * comparison pass through this function): lowercase (Windows drive/case
+ * insensitivity), unify separators, and trim trailing separators.
+ *
+ * Invariant note: neither producer normally emits a trailing separator —
+ * `vscode.Uri.fsPath` strips them (except for filesystem roots like "/" or
+ * "C:\"), and session cwd values come from `process.cwd()` which does the
+ * same. The trim is defensive for cwd values recorded by other tools. A
+ * single-character root ("/") is kept as-is; "c:/" trims to "c:" which stays
+ * equality-consistent because both comparands are normalized identically.
+ */
 export function normalizeWorkspacePath(p: string): string {
-  return p.toLowerCase().replace(/\\/g, '/')
+  const unified = p.toLowerCase().replace(/\\/g, '/')
+  return unified.length > 1 ? unified.replace(/\/+$/, '') : unified
 }
 
 /**
@@ -71,6 +84,10 @@ export function isCrossWorkspace(
  * Picker option list given the cross-workspace flag. Cross → 2 options
  * (Internal / External). Same-workspace → 3 options (Internal / External /
  * Anthropic).
+ *
+ * The ordering is deliberate: the established terminal flavors come first and
+ * the Claude Code Extension entry stays last. Promote it only on real UX
+ * feedback — reordering here is the single place that changes the picker.
  */
 export function pickerOptions(crossWorkspace: boolean): ReadonlyArray<ResumeMode> {
   return crossWorkspace ? ['internal', 'external'] : ['internal', 'external', 'anthropic']

--- a/packages/vscode-extension/src/lib/crossWorkspace.ts
+++ b/packages/vscode-extension/src/lib/crossWorkspace.ts
@@ -153,6 +153,7 @@ export type EnsureClaudeCodeExtensionResult =
   | { kind: 'ready'; extension: ClaudeExtensionLike }
   | { kind: 'declined' }
   | { kind: 'install-pending' }
+  | { kind: 'install-failed'; error: string }
   | { kind: 'activation-failed'; error: string }
 
 const ANTHROPIC_EXTENSION_ID = 'anthropic.claude-code'
@@ -181,7 +182,13 @@ export async function ensureClaudeCodeExtension(
     )
     if (choice !== 'Install') return { kind: 'declined' }
 
-    await deps.installExtension(ANTHROPIC_EXTENSION_ID)
+    try {
+      await deps.installExtension(ANTHROPIC_EXTENSION_ID)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      deps.showErrorMessage(`Failed to install Claude Code extension: ${message}`)
+      return { kind: 'install-failed', error: message }
+    }
 
     // Auto-continue: pick up the freshly installed extension and fall through
     // to activation, so the original resume intent completes without a

--- a/packages/vscode-extension/src/test/suite/commands.test.ts
+++ b/packages/vscode-extension/src/test/suite/commands.test.ts
@@ -131,4 +131,29 @@ suite('Resume Session Quick Pick rendering', () => {
     assert.strictEqual(captured[0].items.length, 2, 'fallback picker offers the 2 terminal flavors')
     assert.strictEqual(captured[0].options?.title, 'Resume Session (fallback)')
   })
+
+  // Regression guard for a CodeRabbit Critical finding on PR #199: the session
+  // ID validation used to sit only inside the anthropic branch, leaving the
+  // internal (terminal.sendText) and external (shell-interpolated spawn)
+  // branches able to dispatch an attacker-crafted session ID (a session file
+  // in a shared repository can be named/renamed arbitrarily) into a shell
+  // command. Validation now runs at the very top of the handler, before any
+  // mode is chosen — so an invalid ID must reject before the picker even
+  // renders, proving no branch (terminal or extension) can be reached with it.
+  test('rejects an invalid session id before any destination — including the picker — is reached', async function () {
+    this.timeout(30000)
+    await vscode.workspace
+      .getConfiguration('claudeSessions')
+      .update('defaultTerminalMode', 'ask', vscode.ConfigurationTarget.Global)
+
+    const captured = captureQuickPick()
+    const maliciousItem = { ...fakeSessionItem, sessionId: 'abc; rm -rf ~ #' }
+    await vscode.commands.executeCommand('claudeSessions.resumeSession', maliciousItem)
+
+    assert.strictEqual(
+      captured.length,
+      0,
+      'an invalid session id must reject before the picker is shown, for any mode'
+    )
+  })
 })

--- a/packages/vscode-extension/src/test/suite/commands.test.ts
+++ b/packages/vscode-extension/src/test/suite/commands.test.ts
@@ -48,3 +48,87 @@ suite('Command Registration Suite', () => {
     )
   })
 })
+
+// Render-path guard for the resume-session Quick Pick (issue 173 finding 5).
+// crossWorkspace.test.ts pins the pure decision function; these tests exercise
+// the command end-to-end up to the rendered Quick Pick items by stubbing
+// vscode.window.showQuickPick and invoking the real command with a fake tree
+// item. The test host opens no workspace folder, so every session cwd is
+// cross-workspace — which deterministically renders the 2-option pickers.
+// The 3-option composition itself is pinned at the decision layer
+// (pickerOptions/decideResume) plus the exhaustive MODE_TO_OPTION mapping in
+// extension.ts; rendering it here would require the host to open a workspace
+// folder whose path survives the disk-coupled projectName round-trip, which is
+// not deterministic across CI platforms.
+suite('Resume Session Quick Pick rendering', () => {
+  type QuickPickFn = typeof vscode.window.showQuickPick
+  let originalShowQuickPick: QuickPickFn
+  let originalMode: unknown
+
+  const fakeSessionItem = {
+    type: 'session' as const,
+    sessionId: 'test-session-id',
+    projectName: '-nonexistent-csessions-render-test',
+    label: 'render test session',
+  }
+
+  suiteSetup(async function () {
+    await ensureExtensionActive(this)
+    originalShowQuickPick = vscode.window.showQuickPick
+    originalMode = vscode.workspace.getConfiguration('claudeSessions').get('defaultTerminalMode')
+  })
+
+  suiteTeardown(async () => {
+    ;(vscode.window as { showQuickPick: QuickPickFn }).showQuickPick = originalShowQuickPick
+    await vscode.workspace
+      .getConfiguration('claudeSessions')
+      .update('defaultTerminalMode', originalMode, vscode.ConfigurationTarget.Global)
+  })
+
+  const captureQuickPick = () => {
+    const captured: { items: vscode.QuickPickItem[]; options?: vscode.QuickPickOptions }[] = []
+    ;(vscode.window as { showQuickPick: QuickPickFn }).showQuickPick = (async (
+      items: readonly vscode.QuickPickItem[] | Thenable<readonly vscode.QuickPickItem[]>,
+      options?: vscode.QuickPickOptions
+    ) => {
+      captured.push({ items: [...(await items)], options })
+      return undefined // user dismisses — command exits without dispatching
+    }) as unknown as QuickPickFn
+    return captured
+  }
+
+  test("defaultTerminalMode='ask' + cross-workspace renders the 2-option picker without the extension entry", async function () {
+    this.timeout(30000)
+    await vscode.workspace
+      .getConfiguration('claudeSessions')
+      .update('defaultTerminalMode', 'ask', vscode.ConfigurationTarget.Global)
+
+    const captured = captureQuickPick()
+    await vscode.commands.executeCommand('claudeSessions.resumeSession', fakeSessionItem)
+
+    assert.strictEqual(captured.length, 1, 'resumeSession must render exactly one Quick Pick')
+    const labels = captured[0].items.map((i) => i.label)
+    assert.strictEqual(labels.length, 2, `expected 2 options, got: ${labels.join(' | ')}`)
+    assert.ok(labels[0].includes('Internal Terminal'), 'first option must be Internal Terminal')
+    assert.ok(labels[1].includes('External Terminal'), 'second option must be External Terminal')
+    assert.ok(
+      labels.every((l) => !l.includes('Claude Code Extension')),
+      'cross-workspace picker must hide the Claude Code Extension entry'
+    )
+    assert.strictEqual(captured[0].options?.title, 'Resume Session')
+  })
+
+  test("defaultTerminalMode='anthropic' + cross-workspace renders the fallback picker", async function () {
+    this.timeout(30000)
+    await vscode.workspace
+      .getConfiguration('claudeSessions')
+      .update('defaultTerminalMode', 'anthropic', vscode.ConfigurationTarget.Global)
+
+    const captured = captureQuickPick()
+    await vscode.commands.executeCommand('claudeSessions.resumeSession', fakeSessionItem)
+
+    assert.strictEqual(captured.length, 1, 'fallback path must render exactly one Quick Pick')
+    assert.strictEqual(captured[0].items.length, 2, 'fallback picker offers the 2 terminal flavors')
+    assert.strictEqual(captured[0].options?.title, 'Resume Session (fallback)')
+  })
+})

--- a/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
+++ b/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
@@ -31,6 +31,37 @@ suite('crossWorkspace Suite', () => {
     test('empty string stays empty', () => {
       assert.strictEqual(normalizeWorkspacePath(''), '')
     })
+
+    test('trims a trailing separator so both comparands canonicalize equal', () => {
+      assert.strictEqual(normalizeWorkspacePath('/users/a/project/'), '/users/a/project')
+      assert.strictEqual(
+        normalizeWorkspacePath('/users/a/project/'),
+        normalizeWorkspacePath('/users/a/project')
+      )
+    })
+
+    test('trims repeated trailing separators (backslash form included)', () => {
+      assert.strictEqual(normalizeWorkspacePath('/users/a/project///'), '/users/a/project')
+      assert.strictEqual(normalizeWorkspacePath('C:\\Users\\A\\Project\\'), 'c:/users/a/project')
+    })
+
+    test('filesystem roots stay equality-consistent', () => {
+      // "/" is kept as-is (the separator IS the path)
+      assert.strictEqual(normalizeWorkspacePath('/'), '/')
+      // "C:\" trims to "c:" — fine for equality because both sides normalize
+      assert.strictEqual(normalizeWorkspacePath('C:\\'), normalizeWorkspacePath('c:/'))
+    })
+
+    test('trailing-slash cwd matches a clean workspace folder end-to-end', () => {
+      assert.strictEqual(
+        matchesAnyWorkspaceFolder('/users/a/project/', [folder('/users/a/project')]),
+        true
+      )
+      assert.strictEqual(
+        matchesAnyWorkspaceFolder('/users/a/project', [folder('/users/a/project/')]),
+        true
+      )
+    })
   })
 
   suite('matchesAnyWorkspaceFolder', () => {

--- a/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
+++ b/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
@@ -457,6 +457,33 @@ suite('ensureClaudeCodeExtension Suite', () => {
     )
   })
 
+  // CodeRabbit finding on PR #199 (crossWorkspace.ts:152-156): a rejected
+  // installExtension call used to propagate uncaught out of the helper —
+  // inconsistent with the other typed failure states and left an unhandled
+  // rejection at the resumeSession call site.
+  test('installExtension rejects — install-failed with the error message, error surfaced, no throw escapes', async () => {
+    const { deps, calls } = makeDeps({
+      getExtension: () => undefined,
+      installExtension: () => {
+        calls.installExtension++
+        return Promise.reject(new Error('marketplace unreachable'))
+      },
+    })
+
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'install-failed')
+    if (result.kind === 'install-failed') {
+      assert.strictEqual(result.error, 'marketplace unreachable')
+    }
+    assert.strictEqual(calls.showErrorMessage, 1)
+    assert.strictEqual(
+      calls.showInformationMessage,
+      0,
+      'install-failed must not also show the re-trigger info message'
+    )
+  })
+
   test('installed-but-disabled — activation runs before ready (PR #172 Internal Code Review #2 regression guard)', async () => {
     let activateCalls = 0
     const disabledExt: ClaudeExtensionLike = {

--- a/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
+++ b/packages/vscode-extension/src/test/suite/crossWorkspace.test.ts
@@ -1,9 +1,12 @@
 import * as assert from 'assert'
 import {
   decideResume,
+  ensureClaudeCodeExtension,
   matchesAnyWorkspaceFolder,
   normalizeWorkspacePath,
+  type ClaudeExtensionLike,
   type DefaultTerminalMode,
+  type EnsureClaudeCodeExtensionDeps,
   type ResumeDecision,
   type WorkspaceFolderLike,
 } from '../../lib/crossWorkspace'
@@ -337,5 +340,153 @@ suite('crossWorkspace Suite', () => {
     // INVARIANT 3/4 (null cwd + empty folders) were covered transitively by
     // INVARIANT 1/2's defaultMode enumeration on top of the matchesAnyWorkspaceFolder
     // null/empty unit tests — removed as redundant.
+  })
+})
+
+// Unit tests for the install-on-demand flow extracted from resumeSession's
+// anthropic branch (issue 173 finding 4's follow-up: this state machine is
+// unreachable via the real resumeSession command in the test-electron host,
+// since no workspace folder is open there and decideResume always routes
+// cross-workspace in that case — see PR #199 discussion). Mock deps exercise
+// every branch deterministically, with zero real vscode API / network calls.
+suite('ensureClaudeCodeExtension Suite', () => {
+  const activeExt: ClaudeExtensionLike = { isActive: true, activate: () => Promise.resolve() }
+
+  const makeDeps = (overrides: Partial<EnsureClaudeCodeExtensionDeps> = {}) => {
+    const calls = {
+      showWarningMessage: 0,
+      installExtension: 0,
+      showInformationMessage: 0,
+      showErrorMessage: 0,
+    }
+    const deps: EnsureClaudeCodeExtensionDeps = {
+      getExtension: () => activeExt,
+      showWarningMessage: () => {
+        calls.showWarningMessage++
+        return Promise.resolve('Install')
+      },
+      installExtension: () => {
+        calls.installExtension++
+        return Promise.resolve()
+      },
+      showInformationMessage: () => {
+        calls.showInformationMessage++
+      },
+      showErrorMessage: () => {
+        calls.showErrorMessage++
+      },
+      ...overrides,
+    }
+    return { deps, calls }
+  }
+
+  test('already installed and active — ready with zero prompts, zero install calls', async () => {
+    const { deps, calls } = makeDeps()
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'ready')
+    assert.strictEqual(calls.showWarningMessage, 0)
+    assert.strictEqual(calls.installExtension, 0)
+  })
+
+  test('not installed + user picks Install + extension appears immediately — auto-continues to ready in one call, zero manual re-trigger', async () => {
+    let installed = false
+    const { deps, calls } = makeDeps({
+      getExtension: () => (installed ? activeExt : undefined),
+      installExtension: () => {
+        calls.installExtension++
+        installed = true
+        return Promise.resolve()
+      },
+    })
+
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'ready', 'must resolve to ready within the single call')
+    assert.strictEqual(calls.installExtension, 1)
+    assert.strictEqual(
+      calls.showInformationMessage,
+      0,
+      'the re-trigger info message must NOT fire when auto-continue succeeds'
+    )
+  })
+
+  test('not installed + user picks Cancel — declined, no install attempted', async () => {
+    const { deps, calls } = makeDeps({
+      getExtension: () => undefined,
+      showWarningMessage: () => {
+        calls.showWarningMessage++
+        return Promise.resolve('Cancel')
+      },
+    })
+
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'declined')
+    assert.strictEqual(calls.installExtension, 0)
+  })
+
+  test('not installed + dismissed (no choice) — declined, same as Cancel', async () => {
+    const { deps, calls } = makeDeps({
+      getExtension: () => undefined,
+      showWarningMessage: () => {
+        calls.showWarningMessage++
+        return Promise.resolve(undefined)
+      },
+    })
+
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'declined')
+    assert.strictEqual(calls.installExtension, 0)
+  })
+
+  test('installed but extension host has not surfaced it yet — install-pending, info message shown once, no throw', async () => {
+    const { deps, calls } = makeDeps({
+      getExtension: () => undefined, // never appears, even after "install"
+    })
+
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'install-pending')
+    assert.strictEqual(calls.installExtension, 1)
+    assert.strictEqual(
+      calls.showInformationMessage,
+      1,
+      'must tell the user to re-trigger — this is the one legitimate manual-retry case'
+    )
+  })
+
+  test('installed-but-disabled — activation runs before ready (PR #172 Internal Code Review #2 regression guard)', async () => {
+    let activateCalls = 0
+    const disabledExt: ClaudeExtensionLike = {
+      isActive: false,
+      activate: () => {
+        activateCalls++
+        return Promise.resolve()
+      },
+    }
+    const { deps } = makeDeps({ getExtension: () => disabledExt })
+
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'ready')
+    assert.strictEqual(activateCalls, 1, 'activate() must run when isActive is false')
+  })
+
+  test('activation throws — activation-failed with the error message, error surfaced', async () => {
+    const failingExt: ClaudeExtensionLike = {
+      isActive: false,
+      activate: () => Promise.reject(new Error('activation boom')),
+    }
+    const { deps, calls } = makeDeps({ getExtension: () => failingExt })
+
+    const result = await ensureClaudeCodeExtension(deps)
+
+    assert.strictEqual(result.kind, 'activation-failed')
+    if (result.kind === 'activation-failed') {
+      assert.strictEqual(result.error, 'activation boom')
+    }
+    assert.strictEqual(calls.showErrorMessage, 1)
   })
 })


### PR DESCRIPTION
## Overview

Works through the deferred Minor findings tracked in issue #173 (post-merge cleanup of PR #172's review): install-flow auto-continue, workspace-path normalization hardening, Quick Pick render-path test coverage, and documentation of the deliberate design choices.

Also fixes a 🔴 Critical finding CodeRabbit raised on this PR: session ID validation was scoped only to the `anthropic` dispatch branch, leaving the `internal`/`external` branches able to act on an unvalidated (and thus shell-injectable) session ID. See the Security section below.

Relates to #173

## Changes by finding

| Finding | Change |
|---------|--------|
| 4 | Install flow auto-continues: after `workbench.extensions.installExtension` resolves, the handler re-queries the extension and falls through to activation + URI dispatch — the original resume intent completes without re-triggering. An info message remains only for the host-not-yet-surfaced edge |
| 5 | New `Resume Session Quick Pick rendering` suite: stubs `showQuickPick` and drives the real command, pinning the cross-workspace 2-option picker (extension entry hidden, primary title) and the anthropic fallback picker. The 3-option composition stays pinned at the decision layer — rendering it deterministically would require a workspace folder whose path survives the disk-coupled projectName round-trip on every CI platform |
| 6 | Documented (code comment + README) why `openTerminalHere` / `startClaudeInFolder` deliberately keep the 2-way terminal picker |
| 7 | Documented the deliberate picker ordering in `pickerOptions` (terminal flavors first, extension entry last; promote only on real UX feedback) |
| 8 | README section for `claudeSessions.defaultTerminalMode` describing all four values (`ask`/`internal`/`external`/`anthropic`), when each skips the picker, and the cross-workspace fallback |
| 9 | The not-installed warning no longer exposes the implementation extension id |
| 10 | Dropped the defensive `String()` coercion on `sessionId` in the anthropic branch. (Superseded by the Security fix below: the validation — now `typeof` + regex — moved to the top of the handler and covers all three branches, not just anthropic.) |
| 13 | `normalizeWorkspacePath` trims trailing separators (defensive; producers normally never emit one) with the invariant + filesystem-root edge cases documented, plus unit tests for trailing/repeated separators, roots, and end-to-end matching |

## Security

**Note**: while verifying the [UI] item below, the install-flow was refactored into a standalone injectable function to make it unit-testable; that refactor surfaced one more real finding (CodeRabbit, 🟠 Major — an uncaught `installExtension` rejection), fixed in the same PR.

CodeRabbit flagged (🔴 Critical) that the session ID regex guard lived only inside the `anthropic` branch — the `internal` branch (`terminal.sendText(cliCommand)`) and `external` branch (`resumeSession` → `startClaude`, which interpolates the ID into a `bash -c` / AppleScript `do script` / `cmd /k` string with no shell-metacharacter escaping) could dispatch an attacker-crafted session ID unvalidated. Since a session file in a shared repository can be named/renamed arbitrarily, this was a real command-injection path.

Fixed by moving `typeof item.sessionId === 'string' && /^[A-Za-z0-9_-]+$/.test(item.sessionId)` to the very top of the `resumeSession` handler, before any mode is selected — one guard, all three branches. The `typeof` check (added after Internal Code Review) closes a secondary gap: `RegExp#test` coerces via `ToString`, so a bare regex check would have accepted `undefined`/`null` as the literal strings `"undefined"`/`"null"`; `resumeSession` is a registered VSCode command reachable via `vscode.commands.executeCommand` with an arbitrary payload from any extension, bypassing `SessionTreeItem`'s compile-time `string` typing.

New regression test proves an invalid ID rejects before the picker is even shown, for any `defaultTerminalMode`.

**Follow-up (tracked separately, not in this PR's diff)**: Internal Code Review found the identical vulnerability, unfixed, in `packages/web`'s `/api/session/resume` HTTP endpoint — it calls the same `resumeSession`/`startClaude` chain with zero validation on the request body's `sessionId`. Filed as a private draft [Security Advisory](https://github.com/es6kr/claude-code-sessions/security/advisories/GHSA-73r5-9hgq-rj58) (not published — avoids broadcasting exploit details before a fix ships).

## Test Plan

- [x] **[general]** Extension host suite: 67 passing (incl. 5 normalization tests, 2 Quick Pick render tests, 1 session-ID-injection regression test, 8 ensureClaudeCodeExtension unit tests), 0 failing
- [x] **[general]** `pnpm lint`: 0 errors, 1 pre-existing baseline warning (`treeProvider.ts:274` max-depth — unrelated)
- [x] **[general]** Security fix verified: regression test reproduces the pre-fix bypass (picker shown for an invalid ID under the old code) and confirms it now rejects before any dispatch, for all `defaultTerminalMode` values via the shared top-of-handler guard
- [x] **[general]** Install-path auto-continue verified via unit tests, not a live GUI click-through: the isolated-VSCode-instance approach turned out to be structurally blocked (the test-electron host opens no workspace folder, so `decideResume` always routes cross-workspace and the `anthropic` branch is unreachable via the real `resumeSession` command there — same limitation already noted for the 3-option picker). Refactored the install-flow into `ensureClaudeCodeExtension` (injectable deps, no vscode imports) and added 8 unit tests covering every state: already-active, auto-continue-in-one-call (the exact behavior this item asks about — zero re-trigger info message), user declines, user dismisses, install-pending (host hasn't surfaced it), installed-but-disabled activation, activation failure, and install rejection (found by CodeRabbit's review of the refactor itself, commit 5d7ce53)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Resume Session” support across internal terminal, external terminal, and the Claude Code extension, including configurable resume modes with fallback behavior.
- **Bug Fixes**
  - Validate session IDs before any UI interaction to prevent unsafe resume attempts.
  - Improved resume handling when the Claude Code extension isn’t ready after install/activation.
  - Enhanced workspace path matching by trimming trailing separators and normalizing path formats.
- **Documentation**
  - Updated the README with clearer resume destination details and resume mode (`defaultTerminalMode`) behavior.
- **Tests**
  - Added coverage for Quick Pick rendering and cross-workspace resume-mode helper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


