### PR TITLE
fix(ci): pass PAT to checkout on semantic-release preview jobs

### DIFF
--- a/.github/workflows/npm-semantic-release.yml
+++ b/.github/workflows/npm-semantic-release.yml
@@ -39,6 +39,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # PAT required here too (not just on the release job's checkout) — without it,
+          # actions/checkout persists the job-scoped (contents:read) default GITHUB_TOKEN as
+          # the local git credential, which wins over the PAT that semantic-release embeds in
+          # its own dry-run push URL. Empirically verified 2026-07-20 (run 29749591279): dry-run
+          # push was denied as `github-actions[bot]` despite the step-level GITHUB_TOKEN env
+          # override below — the ambient credential from checkout took precedence.
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/vsx-semantic-release.yml
+++ b/.github/workflows/vsx-semantic-release.yml
@@ -41,6 +41,14 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # PAT required here too (not just on the release job's checkout) — without it,
+          # actions/checkout persists the job-scoped (contents:read) default GITHUB_TOKEN as
+          # the local git credential, which wins over the PAT that semantic-release embeds in
+          # its own dry-run push URL. Empirically verified 2026-07-20 (run 29749591279, npm
+          # sibling workflow): dry-run push was denied as `github-actions[bot]` despite the
+          # step-level GITHUB_TOKEN env override below — the ambient credential from checkout
+          # took precedence.
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary

- The `preview` job's `actions/checkout@v7` step lacked the `token:` input that the `release` job's checkout already receives.
- Without it, checkout persists the job-scoped (`contents: read`) default `GITHUB_TOKEN` as the local git credential, which wins over the PAT that `semantic-release` embeds in its own dry-run push URL — causing the push to be denied as `github-actions[bot]` regardless of the step-level `GITHUB_TOKEN` env override.
- Fix: add `token: ${{ secrets.RELEASE_PLEASE_PAT }}` to the preview job's checkout in both `npm-semantic-release.yml` and `vsx-semantic-release.yml`, matching the pattern already used by the release job's checkout.

## Verification

- Reproduced via manual `workflow_dispatch` on `production` (run 29749591279) — preview job failed with `EGITNOPERMISSION` / "Permission ... denied to github-actions[bot]".
- Root cause matches a known `actions/checkout` + custom-token conflict pattern (ambient persisted credential outranks an explicitly-embedded push-URL credential).
- Post-merge: propagated to `beta` (5774cc7) then `production` (251c855) — preview jobs succeeded on both branches for both workflows. See comment thread for run details.

## Test Plan

- [x] **[post-merge]** Propagate the fix to `beta` first and confirm `npm-semantic-release.yml` + `vsx-semantic-release.yml` preview jobs no longer fail with EGITNOPERMISSION there — verified, both succeeded
- [x] **[post-merge]** Only after `beta` confirms clean, propagate to `production` and confirm the same — verified, both succeeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preview reliability by ensuring dry-run checks use the intended release credentials.
  * Prevented preview validation from being rejected due to conflicting default credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->