### PR TITLE
ci: apply stash and block fix(ci) tag hook

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -175,8 +175,13 @@ jobs:
       - name: Generate changelog
         if: ${{ github.event_name == 'push' }}
         run: |
-          # Get previous npm tag (v* without vscode prefix)
-          PREV_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | head -2 | tail -1 || echo '')
+          # Get previous tag (exclude current tag; stable releases also skip betas)
+          CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$CURRENT_TAG" == *"-beta"* ]]; then
+            PREV_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -1 || echo '')
+          else
+            PREV_TAG=$(git tag -l 'v[0-9]*' --sort=-v:refname | grep -v -- '-beta' | grep -v "^${CURRENT_TAG}$" | head -1 || echo '')
+          fi
           if [ -n "$PREV_TAG" ]; then
             echo "Generating changelog from $PREV_TAG"
             npx changelogen --from $PREV_TAG --output RELEASE_NOTES.md

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,21 @@
+#!/bin/sh
+COMMIT_MSG_FILE=$1
+
+# Read the first line of the commit message
+FIRST_LINE=$(head -n 1 "$COMMIT_MSG_FILE")
+
+# Check if the first line starts with fix(ci) (case-insensitive check)
+CLEANED_LINE=$(echo "$FIRST_LINE" | tr '[:upper:]' '[:lower:]')
+
+case "$CLEANED_LINE" in
+  "fix(ci)"*)
+    echo "================================================================" >&2
+    echo "ERROR: 'fix(ci):' tags are absolutely forbidden!" >&2
+    echo "Reason: This triggers unwanted patch version bumps in CI." >&2
+    echo "Solution: Use 'ci:' (or 'ci(scope):') instead of 'fix(ci):'." >&2
+    echo "================================================================" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -61,7 +61,7 @@ while read local_ref local_sha remote_ref remote_sha; do
     elif echo "$tag_name" | grep -q "^v"; then
       echo "📦 Version tag detected: $tag_name"
       echo "Running core/mcp/web tests (excluding VSCode)..."
-      run_quiet pnpm -s test:core && run_quiet pnpm -s test:mcp && run_quiet pnpm -s test:web
+      run_quiet pnpm --filter @claude-sessions/core build && run_quiet pnpm -s test:core && run_quiet pnpm -s test:mcp && run_quiet pnpm -s test:web
       exit $?
     fi
   fi


### PR DESCRIPTION
## Summary
- Applies the git stash pop changes (pre-push build, release-please regex fixes).
- Introduces a commit-msg hook to block invalid `fix(ci):` tags and guide towards standard `ci:` tags.
- Upgrades git-repo skill to document and recommend these configurations.

## Changes
| File | Change |
|------|--------|
| .husky/commit-msg | Create hook to block `fix(ci)` commits |
| .husky/pre-push | Run core package build step before push |
| .github/workflows/publish-npm.yml | Fix changelog parsing for beta tags |
| skills/git-repo/SKILL.md | Add ci-guard topic mapping |
| skills/git-repo/clone.md | Recommend ci-guard hook setup |
| skills/git-repo/ci-guard.md | Add commit-msg hook installation guide |

## Related Issues
<!-- Relates to #number — Do NOT use "Closes #" or "Fixes #" to prevent auto-close -->
Relates to #207

## Test plan
- [x] **[general]** Local build of `@claude-sessions/core` passes
- [x] **[general]** `.husky/commit-msg` hook successfully blocks `fix(ci):` and allows `ci:` commits
- [x] **[general]** `.husky/pre-push` hook successfully runs core build before push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release note generation so published notes more accurately reflect changes between the appropriate versions, including beta releases.
  * Added commit validation to prevent CI-specific version-bump commits from being created.
  * Updated pre-push checks to build the core package before running the test suites, improving release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->