### PR TITLE
ci(release): align beta branch config with main's canonical form

### DIFF
--- a/.releaserc-npm.json
+++ b/.releaserc-npm.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["production", { "name": "main", "channel": "next", "prerelease": "next" }],
+  "branches": ["production", { "name": "beta", "channel": "beta", "prerelease": "beta" }],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["production", { "name": "main", "channel": "next", "prerelease": "next" }],
+  "branches": ["production", { "name": "beta", "channel": "beta", "prerelease": "beta" }],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Summary

`beta` is structurally unable to publish. semantic-release reads the *triggered* branch's own `.releaserc.json`/`.releaserc-npm.json`, and both `production` and `beta` still list `{name: "main", channel: "next", prerelease: "next"}` as the prerelease entry — while `main`'s own config already reads `{name: "beta", channel: "beta", prerelease: "beta"}`. Evidence: release job run `29759934202` logged `configured to only publish from production, main`.

This is Phase 1 of `plan-npm-beta-config-restructure.md` (Option A, user-approved). Aligns `production`/`beta`'s config with `main`'s already-correct form. No workflow trigger changes needed (`push: branches: [beta, production]` stays as-is).

This PR is opened as a **draft against `beta` first** (not `production`) per the "beta before production, always" rule — using this PR's CI preview job as the Phase 0 dry-run verification, since local `npx semantic-release --dry-run` repeatedly failed on an unresolved npm/pnpm environment issue (see plan Progress Checklist for the failed local repro attempts).

## What to check in the preview job

- [ ] `npm-semantic-release.yml` preview job output no longer says "configured to only publish from production, main"
- [ ] Preview reports a computed next version with a `-beta.N` suffix
- [ ] `vsx-semantic-release.yml` preview shows the equivalent for the vscode line

**Do not merge without explicit approval** — merging triggers the `beta-vscode`/`beta-npm` environment gate, which is a real publish path.

## Test plan

- [x] Verified via `git show origin/{main,production,beta}:.releaserc*.json` that the asymmetry described above is real (not stale-doc confusion — cross-checked against `.claude/rules/branch-source-matrix.md`, which is a known-stale doc already tracked in Issue #208)
- [ ] Preview job Job Summary confirms a computed `-beta.N` version (post-push, pending CI)