### PR TITLE
fix(web): server-side sessionId and filePath validation

### DIFF
--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -123,7 +123,9 @@ async function ensureWebServer({
 
   // SvelteKit adapter-node only reads PORT env var, not --port CLI arg.
   // Always set PORT in spawn env to ensure it works regardless of entry point.
-  const spawnEnv = { ...process.env, PORT: String(port) }
+  // HOST pins the server to loopback — without it, adapter-node defaults to
+  // 0.0.0.0 (all interfaces), exposing the unauthenticated API to the LAN.
+  const spawnEnv = { ...process.env, PORT: String(port), HOST: '127.0.0.1' }
 
   if (webServerPath) {
     spawnCmd = 'node'

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -4,11 +4,21 @@ import * as session from '@claude-sessions/core'
 import { openExternalTerminal, resumeSession, startClaude } from '@claude-sessions/core/server'
 import { Effect } from 'effect'
 import { spawn, type ChildProcess } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
 import { outputChannel } from './output'
 import { SESSION_EDITOR_VIEW_TYPE, SessionEditorProvider } from './sessionEditorProvider'
 import { decideResume, ensureClaudeCodeExtension, type ResumeMode } from './lib/crossWorkspace'
 
 let webServerProcess: ChildProcess | null = null
+// The one-time-exchange token for the currently-running spawned server, or
+// null if no auth is configured for it. Set only when we actually spawn a
+// new process (see ensureWebServer) — reused across calls within the same
+// activation so the URL builders below can append it. Known limitation: if
+// a server was left running by a *previous* activation (extension host
+// reload without killWebServer), this stays null and URLs open without a
+// token even though the orphaned process may still require one — recovery
+// requires a manual "Restart Web Server" (killWebServer + fresh spawn).
+let webServerAuthToken: string | null = null
 
 function shortLabel(text: string, max = 30): string {
   return text.length > max ? text.slice(0, max - 1) + '…' : text
@@ -91,17 +101,27 @@ function killWebServer(): Promise<void> {
   })
 }
 
+interface WebServerHandle {
+  port: number
+  authToken: string | null
+}
+
+function appendAuthToken(url: string, authToken: string | null): string {
+  if (!authToken) return url
+  return `${url}${url.includes('?') ? '&' : '?'}token=${authToken}`
+}
+
 async function ensureWebServer({
   forceRestart = false,
   skipAutoStartCheck = false,
-} = {}): Promise<number> {
+} = {}): Promise<WebServerHandle> {
   const { port, autoStartServer } = getConfig()
 
   // Check if server is running (skip when force-restarting with new config)
   if (!forceRestart) {
     try {
       const response = await fetch(`http://localhost:${port}/api/version`)
-      if (response.ok) return port
+      if (response.ok) return { port, authToken: webServerAuthToken }
     } catch {
       // Server not running
     }
@@ -121,11 +141,22 @@ async function ensureWebServer({
   let spawnCmd: string
   let spawnArgs: string[]
 
+  // Fresh one-time-exchange token for Layer 3 auth (hooks.server.ts). Passed
+  // via env (never argv) to avoid `ps`-visible exposure — see
+  // plan-claude-sessions-security-hardening.md §Q2.
+  const authToken = randomBytes(32).toString('hex')
+  webServerAuthToken = authToken
+
   // SvelteKit adapter-node only reads PORT env var, not --port CLI arg.
   // Always set PORT in spawn env to ensure it works regardless of entry point.
   // HOST pins the server to loopback — without it, adapter-node defaults to
   // 0.0.0.0 (all interfaces), exposing the unauthenticated API to the LAN.
-  const spawnEnv = { ...process.env, PORT: String(port), HOST: '127.0.0.1' }
+  const spawnEnv = {
+    ...process.env,
+    PORT: String(port),
+    HOST: '127.0.0.1',
+    CLAUDE_SESSIONS_AUTH_TOKEN: authToken,
+  }
 
   if (webServerPath) {
     spawnCmd = 'node'
@@ -174,7 +205,7 @@ async function ensureWebServer({
             outputChannel.appendLine(`Health check passed, waiting 1s for SvelteKit...`)
             await new Promise((r) => setTimeout(r, 1000))
             outputChannel.appendLine(`Server ready on port ${port}`)
-            resolve(port)
+            resolve({ port, authToken })
             return
           }
           outputChannel.appendLine(`Health check returned ${response.status}`)
@@ -332,9 +363,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('claudeSessions.openSession', async (item: SessionTreeItem) => {
       if (item.type === 'session') {
         try {
-          const port = await ensureWebServer()
+          const { port, authToken } = await ensureWebServer()
           const { openInEditor } = getConfig()
-          const localUrl = `http://localhost:${port}/session/${encodeURIComponent(item.projectName)}/${encodeURIComponent(item.sessionId)}`
+          const localUrl = appendAuthToken(
+            `http://localhost:${port}/session/${encodeURIComponent(item.projectName)}/${encodeURIComponent(item.sessionId)}`,
+            authToken
+          )
           const externalUri = await vscode.env.asExternalUri(vscode.Uri.parse(localUrl))
 
           if (openInEditor) {
@@ -393,9 +427,9 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand('claudeSessions.openWebUI', async () => {
       try {
-        const port = await ensureWebServer()
+        const { port, authToken } = await ensureWebServer()
         const externalUri = await vscode.env.asExternalUri(
-          vscode.Uri.parse(`http://localhost:${port}`)
+          vscode.Uri.parse(appendAuthToken(`http://localhost:${port}`, authToken))
         )
         vscode.env.openExternal(externalUri)
       } catch (e) {
@@ -866,12 +900,17 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('claudeSessions.restartWebServer', async () => {
       await killWebServer()
       try {
-        await ensureWebServer({ forceRestart: true, skipAutoStartCheck: true })
+        const handle = await ensureWebServer({ forceRestart: true, skipAutoStartCheck: true })
         vscode.window.showInformationMessage('Web server restarted successfully')
+        // Returned for test/tooling consumers that need the auth token to
+        // make direct HTTP requests (the webview flow gets it via
+        // appendAuthToken above) — not used by the info-message path.
+        return handle
       } catch (err) {
         vscode.window.showErrorMessage(
           `Failed to restart web server: ${err instanceof Error ? err.message : String(err)}`
         )
+        return undefined
       }
     }),
 

--- a/packages/vscode-extension/src/extension.ts
+++ b/packages/vscode-extension/src/extension.ts
@@ -111,6 +111,35 @@ function appendAuthToken(url: string, authToken: string | null): string {
   return `${url}${url.includes('?') ? '&' : '?'}token=${authToken}`
 }
 
+// Version-coupling guard (P2-1): we always pass CLAUDE_SESSIONS_AUTH_TOKEN,
+// but a pinned/older `webServerPath` or `packageTag` may point at a
+// @claude-sessions/web build that predates hooks.server.ts entirely — it
+// would silently ignore the env var and serve unauthenticated. Negotiate via
+// a capability flag (not a semver threshold, which we can't hardcode without
+// knowing this fix's own future release version) and warn once per
+// activation rather than failing closed, matching the plan's "graceful
+// degrade + document" guidance.
+let hasWarnedUnhardenedServer = false
+
+async function warnIfServerUnhardened(response: Response): Promise<void> {
+  if (hasWarnedUnhardenedServer) return
+  try {
+    const body: unknown = await response.json()
+    if (body && typeof body === 'object' && (body as { hardened?: unknown }).hardened === true) {
+      return
+    }
+  } catch (e) {
+    outputChannel.appendLine(`Could not parse /api/version response for hardening check: ${e}`)
+  }
+  hasWarnedUnhardenedServer = true
+  const message =
+    'The running @claude-sessions/web server predates the Host allow-list / token-auth ' +
+    'hardening (webServerPath or packageTag may be pinned to an older build). ' +
+    'The session data it serves is not protected by those layers.'
+  outputChannel.appendLine(`WARNING: ${message}`)
+  vscode.window.showWarningMessage(message)
+}
+
 async function ensureWebServer({
   forceRestart = false,
   skipAutoStartCheck = false,
@@ -121,7 +150,13 @@ async function ensureWebServer({
   if (!forceRestart) {
     try {
       const response = await fetch(`http://localhost:${port}/api/version`)
-      if (response.ok) return { port, authToken: webServerAuthToken }
+      if (response.ok) {
+        // Only meaningful if we know we asked this server to require a
+        // token — an unknown (null) token here just means no spawn has
+        // happened yet this activation, not that hardening is absent.
+        if (webServerAuthToken) void warnIfServerUnhardened(response)
+        return { port, authToken: webServerAuthToken }
+      }
     } catch {
       // Server not running
     }
@@ -201,6 +236,7 @@ async function ensureWebServer({
         try {
           const response = await fetch(`http://localhost:${port}/api/version`)
           if (response.ok) {
+            await warnIfServerUnhardened(response)
             // Wait for SvelteKit to fully initialize
             outputChannel.appendLine(`Health check passed, waiting 1s for SvelteKit...`)
             await new Promise((r) => setTimeout(r, 1000))

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -41,6 +41,45 @@ function createMockSessionTreeItem(projectName: string, sessionId: string) {
   }
 }
 
+interface WebServerHandle {
+  port: number
+  authToken: string | null
+}
+
+function httpGet(
+  url: string,
+  headers: Record<string, string> = {}
+): Promise<{ statusCode: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(url, { headers }, (res) => {
+      let data = ''
+      res.on('data', (chunk: Buffer) => (data += chunk.toString()))
+      res.on('end', () =>
+        resolve({ statusCode: res.statusCode ?? 0, headers: res.headers, body: data })
+      )
+    })
+    req.on('error', reject)
+    req.setTimeout(5000, () => {
+      req.destroy()
+      reject(new Error('HTTP request timeout'))
+    })
+  })
+}
+
+// Raw http.get requests bypass the extension's own URL-building (which
+// appends ?token=), so tests that hit the server directly must replicate
+// the one-time-token → session-cookie exchange (hooks.server.ts Layer 3)
+// themselves when a token is configured.
+async function exchangeTokenForCookie(
+  port: number,
+  authToken: string | null
+): Promise<string | undefined> {
+  if (!authToken) return undefined
+  const result = await httpGet(`http://localhost:${port}/?token=${authToken}`)
+  const setCookie = result.headers['set-cookie']?.[0]
+  return setCookie?.split(';')[0]
+}
+
 suite('Webview Test Suite', () => {
   // Restore webServerPath after tests that override it
   suiteTeardown(async () => {
@@ -327,27 +366,20 @@ suite('Webview Test Suite', () => {
     }
 
     // Ensure web server is running (reuse from previous test or start fresh)
-    await vscode.commands.executeCommand('claudeSessions.restartWebServer')
+    const handle = await vscode.commands.executeCommand<WebServerHandle | undefined>(
+      'claudeSessions.restartWebServer'
+    )
     console.log('restartWebServer executed, polling for server readiness...')
 
     const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
 
-    // Wait for /api/version first (server is ready)
+    // Wait for /api/version first (server is ready) — exempt from Layer 3
+    // auth (see hooks.server.ts PUBLIC_PATHS), so no token needed here.
     const maxRetries = 10
     const retryInterval = 1000
     for (let i = 0; i < maxRetries; i++) {
       try {
-        const result = await new Promise<{ statusCode: number }>((resolve, reject) => {
-          const req = http.get(`http://localhost:${port}/api/version`, (res) => {
-            res.resume()
-            res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
-          })
-          req.on('error', reject)
-          req.setTimeout(3000, () => {
-            req.destroy()
-            reject(new Error('timeout'))
-          })
-        })
+        const result = await httpGet(`http://localhost:${port}/api/version`)
         if (result.statusCode === 200) break
       } catch {
         console.log(`Retry ${i + 1}/${maxRetries}: server not ready yet`)
@@ -355,18 +387,12 @@ suite('Webview Test Suite', () => {
       }
     }
 
+    // Every other path requires Layer 3 auth when a token is configured —
+    // exchange it for a session cookie before checking the actual page.
+    const cookie = await exchangeTokenForCookie(port, handle?.authToken ?? null)
+
     // Now test the frontend root path
-    const rootResult = await new Promise<{ statusCode: number }>((resolve, reject) => {
-      const req = http.get(`http://localhost:${port}/`, (res) => {
-        res.resume()
-        res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
-      })
-      req.on('error', reject)
-      req.setTimeout(5000, () => {
-        req.destroy()
-        reject(new Error('Root path request timeout'))
-      })
-    })
+    const rootResult = await httpGet(`http://localhost:${port}/`, cookie ? { Cookie: cookie } : {})
 
     console.log(`Web server / responded with status: ${rootResult.statusCode}`)
     assert.strictEqual(
@@ -413,27 +439,20 @@ suite('Webview Test Suite', () => {
       return
     }
 
-    await vscode.commands.executeCommand('claudeSessions.restartWebServer')
+    const handle = await vscode.commands.executeCommand<WebServerHandle | undefined>(
+      'claudeSessions.restartWebServer'
+    )
     console.log('restartWebServer executed, polling for server readiness...')
 
     const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
 
-    // Wait for /api/version first (server is ready)
+    // Wait for /api/version first (server is ready) — exempt from Layer 3
+    // auth (see hooks.server.ts PUBLIC_PATHS), so no token needed here.
     const maxRetries = 10
     const retryInterval = 1000
     for (let i = 0; i < maxRetries; i++) {
       try {
-        const result = await new Promise<{ statusCode: number }>((resolve, reject) => {
-          const req = http.get(`http://localhost:${port}/api/version`, (res) => {
-            res.resume()
-            res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
-          })
-          req.on('error', reject)
-          req.setTimeout(3000, () => {
-            req.destroy()
-            reject(new Error('timeout'))
-          })
-        })
+        const result = await httpGet(`http://localhost:${port}/api/version`)
         if (result.statusCode === 200) break
       } catch {
         console.log(`Retry ${i + 1}/${maxRetries}: server not ready yet`)
@@ -441,19 +460,16 @@ suite('Webview Test Suite', () => {
       }
     }
 
+    // Every other path requires Layer 3 auth when a token is configured —
+    // exchange it for a session cookie before checking the actual page.
+    const cookie = await exchangeTokenForCookie(port, handle?.authToken ?? null)
+
     // Now fetch the session page that the VSCode webview actually loads
     const sessionPath = `/session/${encodeURIComponent(sessionInfo.projectName)}/${encodeURIComponent(sessionInfo.sessionId)}`
-    const sessionResult = await new Promise<{ statusCode: number }>((resolve, reject) => {
-      const req = http.get(`http://localhost:${port}${sessionPath}`, (res) => {
-        res.resume()
-        res.on('end', () => resolve({ statusCode: res.statusCode ?? 0 }))
-      })
-      req.on('error', reject)
-      req.setTimeout(5000, () => {
-        req.destroy()
-        reject(new Error('Session page request timeout'))
-      })
-    })
+    const sessionResult = await httpGet(
+      `http://localhost:${port}${sessionPath}`,
+      cookie ? { Cookie: cookie } : {}
+    )
 
     console.log(`Web server ${sessionPath} responded with status: ${sessionResult.statusCode}`)
     assert.strictEqual(

--- a/packages/vscode-extension/src/test/suite/webview.test.ts
+++ b/packages/vscode-extension/src/test/suite/webview.test.ts
@@ -336,6 +336,105 @@ suite('Webview Test Suite', () => {
     assert.ok(parsed.version, 'Response should contain version field')
   })
 
+  // P2-2 regression guard: HOST=127.0.0.1 (P0-1) must actually keep the
+  // server off 0.0.0.0 — verified by attempting a connection via this
+  // machine's own LAN-facing interface, not just parsing `lsof`/`netstat`
+  // output (which is platform-specific and was only a manual check before).
+  test('Web server is not reachable via a LAN-facing interface (loopback-only bind)', async function () {
+    if (process.env.CI) {
+      console.log('Skipping loopback-bind regression test in CI environment')
+      this.skip()
+      return
+    }
+
+    this.timeout(30000)
+
+    const lanAddress = Object.values(os.networkInterfaces())
+      .flat()
+      .find((iface) => iface && iface.family === 'IPv4' && !iface.internal)?.address
+
+    if (!lanAddress) {
+      console.log('No LAN-facing IPv4 interface found on this machine, skipping')
+      this.skip()
+      return
+    }
+
+    const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
+    if (!extension) {
+      assert.fail('Extension not found: es6kr.claude-sessions')
+    }
+    if (!extension.isActive) {
+      await extension.activate()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await vscode.commands.executeCommand('claudeSessions.restartWebServer')
+    const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
+
+    for (let i = 0; i < 10; i++) {
+      try {
+        const result = await httpGet(`http://localhost:${port}/api/version`)
+        if (result.statusCode === 200) break
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+    }
+
+    let reached = false
+    try {
+      await httpGet(`http://${lanAddress}:${port}/api/version`)
+      reached = true
+    } catch (e) {
+      console.log(`LAN-interface connection correctly refused: ${e}`)
+    }
+    assert.strictEqual(
+      reached,
+      false,
+      `Web server should not be reachable via LAN address ${lanAddress}:${port}`
+    )
+  })
+
+  // P2-2 regression guard for P1-1 (Host allow-list) — a spoofed Host header
+  // must be rejected end-to-end against a real running server, not just the
+  // isAllowedHost unit tests in hooks.server.test.ts.
+  test('Web server rejects a spoofed Host header with 403', async function () {
+    if (process.env.CI) {
+      console.log('Skipping Host-header regression test in CI environment')
+      this.skip()
+      return
+    }
+
+    this.timeout(30000)
+
+    const extension = vscode.extensions.getExtension('es6kr.claude-sessions')
+    if (!extension) {
+      assert.fail('Extension not found: es6kr.claude-sessions')
+    }
+    if (!extension.isActive) {
+      await extension.activate()
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    await vscode.commands.executeCommand('claudeSessions.restartWebServer')
+    const port = vscode.workspace.getConfiguration('claudeSessions').get<number>('port', 5174)
+
+    for (let i = 0; i < 10; i++) {
+      try {
+        const result = await httpGet(`http://localhost:${port}/api/version`)
+        if (result.statusCode === 200) break
+      } catch {
+        await new Promise((resolve) => setTimeout(resolve, 1000))
+      }
+    }
+
+    const spoofed = await httpGet(`http://localhost:${port}/api/version`, { Host: 'evil.com' })
+    assert.strictEqual(
+      spoofed.statusCode,
+      403,
+      `A spoofed Host header should be rejected with 403, got ${spoofed.statusCode}`
+    )
+  })
+
   test('Frontend root path responds with HTTP 200', async function () {
     if (process.env.CI) {
       console.log('Skipping frontend root test in CI environment')

--- a/packages/web/src/hooks.server.test.ts
+++ b/packages/web/src/hooks.server.test.ts
@@ -1,5 +1,31 @@
-import { describe, it, expect, vi } from 'vitest'
-import { isAllowedHost, handle } from './hooks.server'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { isAllowedHost } from './hooks.server'
+
+const { envMock } = vi.hoisted(() => ({
+  envMock: {} as Record<string, string | undefined>,
+}))
+
+vi.mock('$env/dynamic/private', () => ({
+  env: envMock,
+}))
+
+function makeCookieStore(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial }
+  return {
+    get: (name: string) => store[name],
+    set: (name: string, value: string) => {
+      store[name] = value
+    },
+  }
+}
+
+function makeEvent(url: string, opts: { host?: string; cookie?: string } = {}) {
+  return {
+    request: new Request(url, opts.host !== undefined ? { headers: { host: opts.host } } : {}),
+    url: new URL(url),
+    cookies: makeCookieStore(opts.cookie !== undefined ? { session: opts.cookie } : {}),
+  }
+}
 
 describe('isAllowedHost', () => {
   it('allows localhost with and without a port', () => {
@@ -47,11 +73,15 @@ describe('isAllowedHost', () => {
   })
 })
 
-describe('handle', () => {
+describe('handle — Layer 2 (Host allow-list)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    for (const key of Object.keys(envMock)) delete envMock[key]
+  })
+
   it('rejects a disallowed Host header with 403 and never calls resolve', async () => {
-    const event = {
-      request: new Request('http://evil.com/api/projects', { headers: { host: 'evil.com' } }),
-    }
+    const { handle } = await import('./hooks.server')
+    const event = makeEvent('http://evil.com/api/projects', { host: 'evil.com' })
     const resolve = vi.fn()
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,18 +89,165 @@ describe('handle', () => {
     expect(resolve).not.toHaveBeenCalled()
   })
 
-  it('resolves normally for an allowed Host header', async () => {
+  it('resolves normally for an allowed Host header when no token is configured', async () => {
+    const { handle } = await import('./hooks.server')
     const response = new Response('ok')
-    const event = {
-      request: new Request('http://127.0.0.1:5174/api/projects', {
-        headers: { host: '127.0.0.1:5174' },
-      }),
-    }
+    const event = makeEvent('http://127.0.0.1:5174/api/projects', { host: '127.0.0.1:5174' })
     const resolve = vi.fn().mockResolvedValue(response)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = await handle({ event, resolve } as any)
     expect(result).toBe(response)
     expect(resolve).toHaveBeenCalledWith(event)
+  })
+})
+
+describe('handle — Layer 3 (one-time token + session cookie)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    for (const key of Object.keys(envMock)) delete envMock[key]
+  })
+
+  it('is disabled (no auth required) when CLAUDE_SESSIONS_AUTH_TOKEN is unset', async () => {
+    const { handle } = await import('./hooks.server')
+    const response = new Response('ok')
+    const event = makeEvent('http://127.0.0.1:5174/session/foo/bar', { host: '127.0.0.1:5174' })
+    const resolve = vi.fn().mockResolvedValue(response)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await handle({ event, resolve } as any)
+    expect(result).toBe(response)
+  })
+
+  it('exempts /api/version from auth even when a token is configured (health-check path)', async () => {
+    envMock.CLAUDE_SESSIONS_AUTH_TOKEN = 'the-real-token'
+    const { handle } = await import('./hooks.server')
+    const response = new Response('ok')
+    const event = makeEvent('http://127.0.0.1:5174/api/version', { host: '127.0.0.1:5174' })
+    const resolve = vi.fn().mockResolvedValue(response)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await handle({ event, resolve } as any)
+    expect(result).toBe(response)
+  })
+
+  it('rejects a request with no cookie and no token with 401', async () => {
+    envMock.CLAUDE_SESSIONS_AUTH_TOKEN = 'the-real-token'
+    const { handle } = await import('./hooks.server')
+    const event = makeEvent('http://127.0.0.1:5174/session/foo/bar', { host: '127.0.0.1:5174' })
+    const resolve = vi.fn()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(handle({ event, resolve } as any)).rejects.toMatchObject({ status: 401 })
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it('exchanges a valid ?token= for a session cookie, strips the token, and redirects', async () => {
+    envMock.CLAUDE_SESSIONS_AUTH_TOKEN = 'the-real-token'
+    const { handle } = await import('./hooks.server')
+    const event = makeEvent('http://127.0.0.1:5174/session/foo/bar?token=the-real-token', {
+      host: '127.0.0.1:5174',
+    })
+    const resolve = vi.fn()
+    const setSpy = vi.spyOn(event.cookies, 'set')
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(handle({ event, resolve } as any)).rejects.toMatchObject({
+      status: 302,
+      location: '/session/foo/bar',
+    })
+    expect(resolve).not.toHaveBeenCalled()
+    expect(setSpy).toHaveBeenCalledWith(
+      'session',
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, sameSite: 'lax', secure: false, path: '/' })
+    )
+  })
+
+  it('rejects an invalid token with 401 without consuming the real token slot', async () => {
+    envMock.CLAUDE_SESSIONS_AUTH_TOKEN = 'the-real-token'
+    const { handle } = await import('./hooks.server')
+
+    const badEvent = makeEvent('http://127.0.0.1:5174/session/foo/bar?token=wrong', {
+      host: '127.0.0.1:5174',
+    })
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handle({ event: badEvent, resolve: vi.fn() } as any)
+    ).rejects.toMatchObject({ status: 401 })
+
+    // The real token must still work — a wrong guess must not burn the
+    // one-time slot (would otherwise let an attacker DoS the legitimate flow).
+    const goodEvent = makeEvent('http://127.0.0.1:5174/session/foo/bar?token=the-real-token', {
+      host: '127.0.0.1:5174',
+    })
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handle({ event: goodEvent, resolve: vi.fn() } as any)
+    ).rejects.toMatchObject({ status: 302 })
+  })
+
+  it('rejects a replayed (already-consumed) token with 401', async () => {
+    envMock.CLAUDE_SESSIONS_AUTH_TOKEN = 'the-real-token'
+    const { handle } = await import('./hooks.server')
+
+    const first = makeEvent('http://127.0.0.1:5174/session/foo/bar?token=the-real-token', {
+      host: '127.0.0.1:5174',
+    })
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handle({ event: first, resolve: vi.fn() } as any)
+    ).rejects.toMatchObject({ status: 302 })
+
+    const replay = makeEvent('http://127.0.0.1:5174/session/foo/bar?token=the-real-token', {
+      host: '127.0.0.1:5174',
+    })
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handle({ event: replay, resolve: vi.fn() } as any)
+    ).rejects.toMatchObject({ status: 401 })
+  })
+
+  it('accepts a request carrying a valid session cookie without the token again', async () => {
+    envMock.CLAUDE_SESSIONS_AUTH_TOKEN = 'the-real-token'
+    const { handle } = await import('./hooks.server')
+
+    // First exchange, to learn the session secret this module instance issues.
+    const exchangeEvent = makeEvent('http://127.0.0.1:5174/?token=the-real-token', {
+      host: '127.0.0.1:5174',
+    })
+    let issuedSecret = ''
+    vi.spyOn(exchangeEvent.cookies, 'set').mockImplementation((_name, value) => {
+      issuedSecret = value
+    })
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handle({ event: exchangeEvent, resolve: vi.fn() } as any)
+    ).rejects.toMatchObject({ status: 302 })
+    expect(issuedSecret).not.toBe('')
+
+    const response = new Response('ok')
+    const cookieEvent = makeEvent('http://127.0.0.1:5174/session/foo/bar', {
+      host: '127.0.0.1:5174',
+      cookie: issuedSecret,
+    })
+    const resolve = vi.fn().mockResolvedValue(response)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await handle({ event: cookieEvent, resolve } as any)
+    expect(result).toBe(response)
+  })
+
+  it('rejects a forged/guessed session cookie with 401', async () => {
+    envMock.CLAUDE_SESSIONS_AUTH_TOKEN = 'the-real-token'
+    const { handle } = await import('./hooks.server')
+    const event = makeEvent('http://127.0.0.1:5174/session/foo/bar', {
+      host: '127.0.0.1:5174',
+      cookie: 'guessed-value',
+    })
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      handle({ event, resolve: vi.fn() } as any)
+    ).rejects.toMatchObject({ status: 401 })
   })
 })

--- a/packages/web/src/hooks.server.test.ts
+++ b/packages/web/src/hooks.server.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { isAllowedHost, handle } from './hooks.server'
+
+describe('isAllowedHost', () => {
+  it('allows localhost with and without a port', () => {
+    expect(isAllowedHost('localhost')).toBe(true)
+    expect(isAllowedHost('localhost:5174')).toBe(true)
+  })
+
+  it('allows the 127.0.0.0/8 loopback range', () => {
+    expect(isAllowedHost('127.0.0.1')).toBe(true)
+    expect(isAllowedHost('127.0.0.1:5174')).toBe(true)
+    expect(isAllowedHost('127.255.255.254')).toBe(true)
+  })
+
+  it('allows IPv6 loopback in bracket notation, with and without a port', () => {
+    expect(isAllowedHost('[::1]')).toBe(true)
+    expect(isAllowedHost('[::1]:5174')).toBe(true)
+  })
+
+  it('normalizes case and a trailing dot', () => {
+    expect(isAllowedHost('LOCALHOST')).toBe(true)
+    expect(isAllowedHost('localhost.')).toBe(true)
+    expect(isAllowedHost('localhost.:5174')).toBe(true)
+  })
+
+  it('rejects an attacker-controlled Host used for DNS rebinding', () => {
+    expect(isAllowedHost('evil.com')).toBe(false)
+    expect(isAllowedHost('evil.com:5174')).toBe(false)
+  })
+
+  it('rejects a same-LAN victim IP outside the loopback range', () => {
+    expect(isAllowedHost('192.168.1.10')).toBe(false)
+  })
+
+  it('rejects decimal/hex-encoded loopback IPs (unsupported, not a security hole)', () => {
+    expect(isAllowedHost('2130706433')).toBe(false)
+    expect(isAllowedHost('0x7f000001')).toBe(false)
+  })
+
+  it('rejects a missing Host header', () => {
+    expect(isAllowedHost(null)).toBe(false)
+  })
+
+  it('rejects a malformed IPv6 bracket literal', () => {
+    expect(isAllowedHost('[::1')).toBe(false)
+  })
+})
+
+describe('handle', () => {
+  it('rejects a disallowed Host header with 403 and never calls resolve', async () => {
+    const event = {
+      request: new Request('http://evil.com/api/projects', { headers: { host: 'evil.com' } }),
+    }
+    const resolve = vi.fn()
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(handle({ event, resolve } as any)).rejects.toMatchObject({ status: 403 })
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it('resolves normally for an allowed Host header', async () => {
+    const response = new Response('ok')
+    const event = {
+      request: new Request('http://127.0.0.1:5174/api/projects', {
+        headers: { host: '127.0.0.1:5174' },
+      }),
+    }
+    const resolve = vi.fn().mockResolvedValue(response)
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await handle({ event, resolve } as any)
+    expect(result).toBe(response)
+    expect(resolve).toHaveBeenCalledWith(event)
+  })
+})

--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -1,0 +1,47 @@
+import { error, type Handle } from '@sveltejs/kit'
+
+// DNS-rebinding / LAN-access defense (Layer 2): reject any request whose Host
+// header doesn't name this loopback server itself. GET requests carry no
+// Origin header, so Host is the only anchor available — see
+// plan-claude-sessions-security-hardening.md §Q3 for why Host validation
+// (not Origin/CORS/Private-Network-Access) is the necessary-and-sufficient,
+// browser-agnostic defense against a remote page rebinding to 127.0.0.1.
+export function isAllowedHost(hostHeader: string | null): boolean {
+  if (!hostHeader) return false
+
+  let hostname: string
+  if (hostHeader.startsWith('[')) {
+    // IPv6 literal in bracket notation, e.g. "[::1]:5174" or "[::1]".
+    // host.split(':')[0] would truncate at the first colon inside the
+    // brackets — extract everything between the brackets instead.
+    const closeBracket = hostHeader.indexOf(']')
+    if (closeBracket === -1) return false
+    hostname = hostHeader.slice(1, closeBracket)
+  } else {
+    // hostname[:port] or IPv4[:port] — at most one colon, so split(':')[0]
+    // is safe here (only the bracketed-IPv6 case above needs special care).
+    hostname = hostHeader.split(':')[0]
+  }
+
+  hostname = hostname.toLowerCase().replace(/\.$/, '')
+
+  if (hostname === 'localhost' || hostname === '::1') return true
+
+  // 127.0.0.0/8
+  const ipv4Match = hostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/)
+  if (ipv4Match) {
+    const octets = ipv4Match.slice(1).map(Number)
+    if (octets.every((octet) => octet <= 255) && octets[0] === 127) {
+      return true
+    }
+  }
+
+  return false
+}
+
+export const handle: Handle = async ({ event, resolve }) => {
+  if (!isAllowedHost(event.request.headers.get('host'))) {
+    throw error(403, 'Forbidden: untrusted Host header')
+  }
+  return resolve(event)
+}

--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -1,4 +1,6 @@
-import { error, type Handle } from '@sveltejs/kit'
+import { error, redirect, type Handle, type RequestEvent } from '@sveltejs/kit'
+import { randomBytes, timingSafeEqual } from 'node:crypto'
+import { env } from '$env/dynamic/private'
 
 // DNS-rebinding / LAN-access defense (Layer 2): reject any request whose Host
 // header doesn't name this loopback server itself. GET requests carry no
@@ -39,9 +41,79 @@ export function isAllowedHost(hostHeader: string | null): boolean {
   return false
 }
 
+// Layer 3 — one-time token exchange + session cookie. Fixes the 3 flaws the
+// plan doc's §Q2 review found in the original brief sketch: (1) the token
+// wasn't actually single-use, (2) the cookie value was a guessable constant,
+// (3) the token leaked via the URL indefinitely. Auth only activates when
+// CLAUDE_SESSIONS_AUTH_TOKEN is set — its absence preserves today's no-auth
+// behavior for the standalone `npx @claude-sessions/web` CLI, which (like
+// HOST/loopback-binding) doesn't provision one.
+const SESSION_COOKIE = 'session'
+// A fresh random secret for the cookie, independent of AUTH_TOKEN — issued
+// once per server process and never exposed in a URL or log the way the
+// one-time exchange token is.
+const SESSION_SECRET = randomBytes(32).toString('hex')
+let tokenConsumed = false
+
+// The extension's own health-check polling (ensureWebServer in
+// extension.ts) hits this before it has any token to send — exempt it.
+// Read-only, minimal information disclosure (a version string).
+const PUBLIC_PATHS = new Set(['/api/version'])
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a)
+  const bufB = Buffer.from(b)
+  return bufA.length === bufB.length && timingSafeEqual(bufA, bufB)
+}
+
+// Synchronous check-and-set: no `await` between the check and the set, so
+// two concurrent requests racing with the correct token cannot both pass
+// (the plan doc's TOCTOU fix vs. the brief sketch, which set `used` in a
+// separate step after the comparison). A wrong token never touches
+// `tokenConsumed`, so a probing attacker can't burn the real one-time slot.
+function tryConsumeToken(candidate: string, authToken: string): boolean {
+  if (tokenConsumed) return false
+  if (!timingSafeStringEqual(candidate, authToken)) return false
+  tokenConsumed = true
+  return true
+}
+
+function hasValidSessionCookie(event: RequestEvent): boolean {
+  const cookie = event.cookies.get(SESSION_COOKIE)
+  return cookie !== undefined && timingSafeStringEqual(cookie, SESSION_SECRET)
+}
+
+function enforceTokenAuth(event: RequestEvent): void {
+  const authToken = env.CLAUDE_SESSIONS_AUTH_TOKEN
+  if (!authToken) return // Layer 3 disabled — no token configured
+  if (PUBLIC_PATHS.has(event.url.pathname)) return
+  if (hasValidSessionCookie(event)) return
+
+  const queryToken = event.url.searchParams.get('token')
+  if (queryToken && tryConsumeToken(queryToken, authToken)) {
+    event.cookies.set(SESSION_COOKIE, SESSION_SECRET, {
+      path: '/',
+      httpOnly: true,
+      sameSite: 'lax',
+      // Loopback-only plain HTTP (never TLS) — `secure: true` would silently
+      // drop the cookie. See plan doc §Q2 for the SameSite=Lax / Simple
+      // Browser cookie-retransmission rationale.
+      secure: false,
+    })
+    // Strip the one-time token from the URL immediately — query params can
+    // leak via Referer headers, browser history, and server access logs.
+    const stripped = new URL(event.url)
+    stripped.searchParams.delete('token')
+    throw redirect(302, stripped.pathname + stripped.search)
+  }
+
+  throw error(401, 'Unauthorized: missing or invalid session')
+}
+
 export const handle: Handle = async ({ event, resolve }) => {
   if (!isAllowedHost(event.request.headers.get('host'))) {
     throw error(403, 'Forbidden: untrusted Host header')
   }
+  enforceTokenAuth(event)
   return resolve(event)
 }

--- a/packages/web/src/routes/api/open-file/+server.ts
+++ b/packages/web/src/routes/api/open-file/+server.ts
@@ -1,12 +1,12 @@
 import { json, error } from '@sveltejs/kit'
-import { exec } from 'child_process'
+import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { homedir } from 'os'
 import { join } from 'path'
 import { env } from '$env/dynamic/private'
 import type { RequestHandler } from './$types'
 
-const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 
 /**
  * Expand ~ to configured home directory or system homedir
@@ -47,7 +47,13 @@ export const POST: RequestHandler = async ({ request }) => {
 
   try {
     const editorCommand = getEditorCommand()
-    await execAsync(`${editorCommand} "${filePath}"`)
+    // execFile never goes through a shell, so filePath (or an
+    // attacker-supplied payload like `; rm -rf ~ #`) cannot be interpreted
+    // as a command regardless of its contents. CLAUDE_SESSIONS_EDITOR may
+    // itself be a multi-token string (e.g. "code --wait") — split it into
+    // the binary plus its own leading args, then append filePath last.
+    const [editorBin, ...editorArgs] = editorCommand.trim().split(/\s+/)
+    await execFileAsync(editorBin, [...editorArgs, filePath])
     return json({ success: true })
   } catch (e) {
     throw error(500, `Failed to open file: ${e}`)

--- a/packages/web/src/routes/api/open-file/server.test.ts
+++ b/packages/web/src/routes/api/open-file/server.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { promisify } from 'util'
+
+const { execFileMock, envMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  envMock: {} as Record<string, string | undefined>,
+}))
+
+vi.mock('child_process', () => ({
+  execFile: Object.assign(vi.fn(), {
+    [promisify.custom]: (...args: unknown[]) => execFileMock(...args),
+  }),
+}))
+
+vi.mock('$env/dynamic/private', () => ({
+  env: envMock,
+}))
+
+import { POST } from './+server'
+
+describe('POST /api/open-file', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    execFileMock.mockResolvedValue({ stdout: '', stderr: '' })
+    for (const key of Object.keys(envMock)) delete envMock[key]
+  })
+
+  it('opens a normal file path via execFile with argv-separated args (no shell)', async () => {
+    const request = new Request('http://localhost/api/open-file', {
+      method: 'POST',
+      body: JSON.stringify({ filePath: '/tmp/example.txt' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST({ request } as never)
+    const data = await response.json()
+
+    expect(data).toEqual({ success: true })
+    expect(execFileMock).toHaveBeenCalledWith('code', ['/tmp/example.txt'])
+  })
+
+  it('treats a shell-injection payload as a literal filename argument, not a command', async () => {
+    const payload = '/tmp/foo"; touch /tmp/pwned #'
+    const request = new Request('http://localhost/api/open-file', {
+      method: 'POST',
+      body: JSON.stringify({ filePath: payload }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST({ request } as never)
+    await response.json()
+
+    // execFile never spawns a shell, so the entire payload is passed as a
+    // single argv element -- there is no way to split it into a second command.
+    expect(execFileMock).toHaveBeenCalledWith('code', [payload])
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('splits a multi-token editor command into binary + leading args', async () => {
+    envMock.CLAUDE_SESSIONS_EDITOR = 'code --wait'
+
+    const request = new Request('http://localhost/api/open-file', {
+      method: 'POST',
+      body: JSON.stringify({ filePath: '/tmp/example.txt' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    await POST({ request } as never)
+
+    expect(execFileMock).toHaveBeenCalledWith('code', ['--wait', '/tmp/example.txt'])
+  })
+
+  it('returns 400 when neither filePath nor sessionId+backupFileName is provided', async () => {
+    const request = new Request('http://localhost/api/open-file', {
+      method: 'POST',
+      body: JSON.stringify({}),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    await expect(POST({ request } as never)).rejects.toThrow()
+  })
+})

--- a/packages/web/src/routes/api/version/+server.ts
+++ b/packages/web/src/routes/api/version/+server.ts
@@ -20,5 +20,11 @@ export const GET: RequestHandler = async () => {
     version: __APP_VERSION__,
     homeDir: env.CLAUDE_SESSIONS_HOME || homedir(),
     currentProjectName: getCurrentProjectName(),
+    // Capability flag (not a version-number threshold — see
+    // plan-claude-sessions-security-hardening.md §Q4 P2-1): older
+    // @claude-sessions/web builds don't have hooks.server.ts at all and
+    // won't include this field, so its absence is itself the signal that
+    // Host allow-listing / token auth are not enforced by this server.
+    hardened: true,
   })
 }


### PR DESCRIPTION
Server-side hardening for two shell-injection vectors in @claude-sessions/web. Advisory: https://github.com/es6kr/claude-code-sessions/security/advisories/GHSA-73r5-9hgq-rj58