### PR TITLE
fix(web): validate sessionId format in POST /api/session/resume

### DIFF
--- a/packages/web/src/routes/api/session/resume/+server.ts
+++ b/packages/web/src/routes/api/session/resume/+server.ts
@@ -13,6 +13,17 @@ export const POST: RequestHandler = async ({ request }) => {
       return json({ error: 'Missing projectName or sessionId' }, { status: 400 })
     }
 
+    // Defense in depth: sessionId is interpolated into a spawned CLI argv
+    // (resumeSession -> claudeArgs) and ultimately into a shell string on
+    // some platforms (AppleScript do script / bash -c / cmd). The Host
+    // allow-list + one-time-token auth in hooks.server.ts already restrict
+    // who can reach this endpoint, but the value itself is still
+    // unvalidated -- mirror the same allow-list regex the vscode-extension
+    // already applies to its own resume/openTerminalHere handlers.
+    if (typeof sessionId !== 'string' || !/^[A-Za-z0-9_-]+$/.test(sessionId)) {
+      return json({ error: 'Invalid session id' }, { status: 400 })
+    }
+
     // Get project path for cwd
     const folderPath = await folderNameToPath(projectName)
     const homeDir = os.homedir()

--- a/packages/web/src/routes/api/session/resume/server.test.ts
+++ b/packages/web/src/routes/api/session/resume/server.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { resumeSessionMock } = vi.hoisted(() => ({
+  resumeSessionMock: vi.fn(),
+}))
+
+vi.mock('@claude-sessions/core/server', () => ({
+  resumeSession: resumeSessionMock,
+}))
+
+vi.mock('@claude-sessions/core', () => ({
+  folderNameToPath: vi.fn().mockResolvedValue('/project'),
+  expandHomePath: vi.fn((path: string) => path),
+}))
+
+import { POST } from './+server'
+
+describe('POST /api/session/resume', () => {
+  beforeEach(() => {
+    resumeSessionMock.mockReset()
+    resumeSessionMock.mockReturnValue({ success: true, pid: 1234 })
+  })
+
+  it('resumes a session with a valid sessionId', async () => {
+    const request = new Request('http://localhost/api/session/resume', {
+      method: 'POST',
+      body: JSON.stringify({ projectName: 'test-project', sessionId: 'session-id-abc123' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST({ request } as never)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ success: true, pid: 1234 })
+    expect(resumeSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-id-abc123' })
+    )
+  })
+
+  it('rejects a sessionId carrying a shell-injection payload without ever calling resumeSession', async () => {
+    const payload = 'session-id"; touch /tmp/pwned #'
+    const request = new Request('http://localhost/api/session/resume', {
+      method: 'POST',
+      body: JSON.stringify({ projectName: 'test-project', sessionId: payload }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST({ request } as never)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ error: 'Invalid session id' })
+    expect(resumeSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a sessionId containing whitespace or other disallowed characters', async () => {
+    const request = new Request('http://localhost/api/session/resume', {
+      method: 'POST',
+      body: JSON.stringify({ projectName: 'test-project', sessionId: 'not a valid id' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST({ request } as never)
+    const data = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(data).toEqual({ error: 'Invalid session id' })
+    expect(resumeSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a real UUID-shaped sessionId', async () => {
+    const request = new Request('http://localhost/api/session/resume', {
+      method: 'POST',
+      body: JSON.stringify({
+        projectName: 'test-project',
+        sessionId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    const response = await POST({ request } as never)
+
+    expect(response.status).toBe(200)
+    expect(resumeSessionMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Defense in depth for the sessionId shell-injection vector documented in [GHSA-73r5-9hgq-rj58](https://github.com/es6kr/claude-code-sessions/security/advisories/GHSA-73r5-9hgq-rj58). PR #216 added Host allow-list + one-time-token auth (`hooks.server.ts`), which restrict who can reach this endpoint, but the `sessionId` value itself was still passed to `resumeSession()` -> `claudeArgs` unvalidated.

## Fix

Mirror the same allow-list regex (`^[A-Za-z0-9_-]+$`) the vscode-extension already applies to its own resume handlers, in `packages/web/src/routes/api/session/resume/+server.ts`.

## Test plan

- [x] **[general]** New unit tests (4): valid sessionId resumes normally, shell-injection payload rejected with 400 before `resumeSession` is called, whitespace/disallowed-character payload rejected, UUID-shaped sessionId passes
- [x] **[general]** Full web test suite: 129/129 passing
- [x] **[general]** `svelte-check`: 0 errors
- [x] **[general]** Live verification: built server + `curl` with an injection payload (`"; touch /tmp/pwned-marker #`) -> `{"error":"Invalid session id"}` (400), marker file never created; a UUID-shaped sessionId still resolves normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for session IDs when resuming sessions.
  * Invalid IDs now return a clear HTTP 400 error instead of being processed.

* **Tests**
  * Added coverage for valid, UUID-shaped, whitespace-containing, and malicious session IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->